### PR TITLE
fix: make / go to /edit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ function App({ docUrl }: { docUrl: AutomergeUrl }) {
       <BrowserRouter>
         <NavBar />
         <Routes>
+          <Route path="/" element={<Editor docUrl={docUrl} />} />
           <Route path="/edit" element={<Editor docUrl={docUrl} />} />
           <Route path="/options" element={<Options />} />
         </Routes>


### PR DESCRIPTION
## Description
Fixed a warning which was rightfully saying that "/" route is not defined.

## Related Issue
[Cite any related issue(s) here]

## Screenshots (_if applicable_)
[Attach screenshots if they help illustrate the changes]

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
