### PR TITLE
Add sidebar heading component

### DIFF
--- a/src/renderer/src/Editor/index.tsx
+++ b/src/renderer/src/Editor/index.tsx
@@ -6,8 +6,9 @@ import { repo } from '../automerge/repo';
 import { Button } from '../components/actions/Button';
 import { Link } from '../components/actions/Link';
 import { Modal } from '../components/dialogs/Modal';
-import { PenIcon } from '../components/icons';
+import { PenIcon, FolderIcon } from '../components/icons';
 import { PersonalFile } from '../components/illustrations/PersonalFile';
+import { SidebarHeading } from '../components/sidebar/SidebarHeading';
 
 const persistDocumentUrl = (docUrl: AutomergeUrl, docTitle: string) => {
   const currentDocUrls = localStorage.getItem('docUrls');
@@ -111,7 +112,7 @@ export const EditorIndex = () => {
       </Modal>
       {docs.length > 0 && (
         <div className="h-full w-2/5 grow-0 p-5 overflow-y-auto border-r border-gray-300 dark:border-neutral-600">
-          <h2>My documents</h2>
+          <SidebarHeading icon={FolderIcon} text="File Explorer" />
           {docs.map((doc) => (
             <div className="text-left" key={doc.id}>
               <Link to={`/edit/${doc.id}`}>{doc.title}</Link>

--- a/src/renderer/src/components/sidebar/SidebarHeading.stories.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeading.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentProps } from 'react';
+
+import { FolderIcon } from '../../components/icons';
+import { SidebarHeading } from './SidebarHeading';
+
+const meta: Meta<typeof SidebarHeading> = {
+  title: 'sidebar/Heading',
+  component: SidebarHeading,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+type Story = StoryObj<ComponentProps<typeof SidebarHeading>>;
+
+export const WithIcon: Story = {
+  args: {
+    icon: FolderIcon,
+    text: 'File Explorer',
+  },
+};
+
+export const HeadingOnly: Story = {
+  args: {
+    text: 'File Explorer',
+  },
+};
+
+export default meta;

--- a/src/renderer/src/components/sidebar/SidebarHeading.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeading.tsx
@@ -1,0 +1,17 @@
+import { IconProps } from '../../components/icons/types';
+
+type SidebarHeadingProps = {
+  icon?: React.ComponentType<IconProps>;
+  text: string;
+};
+
+export const SidebarHeading = ({ icon: Icon, text }: SidebarHeadingProps) => (
+  <div className="flex gap-x-2 items-center mb-4">
+    {Icon && (
+      <Icon className="text-black text-opacity-75 dark:text-white dark:text-opacity-75" />
+    )}
+    <h3 className="font-bold text-base/4 text-black dark:text-white text-opacity-75 dark:text-opacity-75">
+      {text}
+    </h3>
+  </div>
+);

--- a/src/renderer/src/pages/History/Document/CommitView.tsx
+++ b/src/renderer/src/pages/History/Document/CommitView.tsx
@@ -1,13 +1,14 @@
 import { AutomergeUrl } from '@automerge/automerge-repo';
 import { default as Automerge, view } from '@automerge/automerge/next';
 import React, { useCallback, useEffect } from 'react';
-import { ChangeLog, Commit } from './ChangeLog';
-
 import { useDocument } from '@automerge/automerge-repo-react-hooks';
 import { decodeChange, getAllChanges } from '@automerge/automerge/next';
 import { useNavigate } from 'react-router-dom';
+
+import { ChangeLog, Commit } from './ChangeLog';
 import { VersionedDocument, isCommit } from '../../../automerge';
 import { CommitHistoryIcon } from '../../../components/icons';
+import { SidebarHeading } from '../../../components/sidebar/SidebarHeading';
 
 export const CommitView = ({ documentId }: { documentId: AutomergeUrl }) => {
   const [versionedDocument] = useDocument<VersionedDocument>(documentId);
@@ -66,10 +67,7 @@ export const CommitView = ({ documentId }: { documentId: AutomergeUrl }) => {
     <div className="flex-auto flex">
       <div className="h-full w-2/5 grow-0 p-5 overflow-y-auto border-r border-gray-300 dark:border-neutral-600">
         <div className="flex-auto h-full break-words">
-          <div className="flex-auto flex text-left w-full font-bold mb-5 text-sm">
-            <CommitHistoryIcon />
-            Version History
-          </div>
+          <SidebarHeading icon={CommitHistoryIcon} text="Version History" />
           <ChangeLog
             changes={commits}
             onClick={handleCommitClick}

--- a/src/renderer/src/pages/History/Document/DocumentsHistory.tsx
+++ b/src/renderer/src/pages/History/Document/DocumentsHistory.tsx
@@ -8,6 +8,7 @@ import { decodeChange, getAllChanges } from '@automerge/automerge/next';
 import { useNavigate } from 'react-router-dom';
 import { VersionedDocument, isCommit } from '../../../automerge';
 import { CommitHistoryIcon } from '../../../components/icons';
+import { SidebarHeading } from '../../../components/sidebar/SidebarHeading';
 
 export const DocumentsHistory = ({
   documentId,
@@ -70,10 +71,7 @@ export const DocumentsHistory = ({
     <div className="flex-auto flex">
       <div className="h-full w-2/5 grow-0 p-5 overflow-y-auto border-r border-gray-300 dark:border-neutral-600">
         <div className="flex-auto h-full break-words">
-          <div className="flex-auto flex text-left w-full font-bold mb-5 text-sm">
-            <CommitHistoryIcon />
-            Version History
-          </div>
+          <SidebarHeading icon={CommitHistoryIcon} text="Version History" />
           <ChangeLog
             changes={commits}
             onClick={handleCommitClick}

--- a/src/renderer/src/pages/History/History.tsx
+++ b/src/renderer/src/pages/History/History.tsx
@@ -2,7 +2,9 @@ import { AutomergeUrl, isValidAutomergeUrl } from '@automerge/automerge-repo';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Link } from '../../components/actions/Link';
+import { FolderIcon } from '../../components/icons';
 import { PersonalFile } from '../../components/illustrations/PersonalFile';
+import { SidebarHeading } from '../../components/sidebar/SidebarHeading';
 import { DocumentsHistory } from './Document/DocumentsHistory';
 import { InvalidDocument } from './InvalidDocument/InvalidDocument';
 
@@ -28,7 +30,7 @@ const DocumentList = () => {
 
   return (
     <>
-      <h2>My documents</h2>
+      <SidebarHeading icon={FolderIcon} text="File Explorer" />
       {docs.map((doc) => (
         <div className="text-left" key={doc.id}>
           <Link to={`/history/${doc.id}`}>{doc.title}</Link>


### PR DESCRIPTION
## Description

This PR adds a reusable sidebar heading component and the corresponding story.

![Screenshot 2024-04-26 at 4 37 55 PM](https://github.com/stathismor/flow/assets/4354335/6176a580-5658-439a-a069-451d9f633422)
![Screenshot 2024-04-26 at 4 38 01 PM](https://github.com/stathismor/flow/assets/4354335/2b58a2ac-b420-4d4f-a484-55cc3fcd5f2d)

## Related Issue

#71 

## Screenshots (_if applicable_)
[Attach screenshots if they help illustrate the changes]

## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
