### PR TITLE
fix: remove unneeded scrollbar in document history view

### DIFF
--- a/src/renderer/src/pages/History/Document/DocumentsHistory.tsx
+++ b/src/renderer/src/pages/History/Document/DocumentsHistory.tsx
@@ -68,18 +68,16 @@ export const DocumentsHistory = ({
   };
 
   return (
-    <div className="flex-auto flex">
-      <div className="h-full w-2/5 grow-0 p-5 overflow-y-auto border-r border-gray-300 dark:border-neutral-600">
-        <div className="flex-auto h-full break-words">
-          <SidebarHeading icon={CommitHistoryIcon} text="Version History" />
-          <ChangeLog
-            changes={commits}
-            onClick={handleCommitClick}
-            selectedCommit={selectedCommit}
-          />
-        </div>
+    <div className="flex-auto flex items-stretch">
+      <div className="w-2/5 grow-0 border-r border-gray-300 dark:border-neutral-600 p-5 break-words">
+        <SidebarHeading icon={CommitHistoryIcon} text="Version History" />
+        <ChangeLog
+          changes={commits}
+          onClick={handleCommitClick}
+          selectedCommit={selectedCommit}
+        />
       </div>
-      <div className="h-full w-full grow">
+      <div className="w-full grow flex items-stretch">
         <textarea
           id="message"
           value={docValue}
@@ -87,7 +85,7 @@ export const DocumentsHistory = ({
           onDoubleClick={() => navigate(`/edit/${documentId}`)}
           onKeyDown={() => navigate(`/edit/${documentId}`)}
           rows={4}
-          className="bg-inherit focus:shadow-inner h-full w-full resize-none p-5 outline-none"
+          className="bg-inherit focus:shadow-inner w-full resize-none p-5 outline-none"
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

There is an unneeded vertical scrollbar if you select a document in the document history view.

This PR removes the unneeded scrollbar.

## Related Issue

#75 

## Screenshots (_if applicable_)

![nikiforos](https://github.com/stathismor/flow/assets/4354335/8a00ee4a-6bb9-438c-bde6-ca27b79b4a2e)

Unfortunately I need to connect a mouse to take a proper screenshot in Macbook.

## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
