### PR TITLE
Implement file selection using IndexedDB

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import './App.css';
-import { EditorIndex } from './Editor/index';
+import { Editor } from './Editor/index';
 
 import { History } from './pages/History/History';
 import { Options } from './pages/Options/Options';
@@ -9,9 +9,9 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<EditorIndex />} />
-        <Route path="/edit" element={<EditorIndex />}>
-          <Route path=":documentId" element={<EditorIndex />} />
+        <Route path="/" element={<Editor />} />
+        <Route path="/edit" element={<Editor />}>
+          <Route path=":documentId" element={<Editor />} />
         </Route>
         <Route path="history" element={<History />}>
           <Route path=":documentId" element={<History />} />

--- a/src/renderer/src/Editor/FileExplorer.tsx
+++ b/src/renderer/src/Editor/FileExplorer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { clsx } from 'clsx';
 import { AutomergeUrl } from '@automerge/automerge-repo';
 
@@ -10,6 +9,7 @@ import { readFile } from '../filesystem';
 export const FileExplorer = ({
   directoryHandle,
   files,
+  selectedFileHandle,
   setDirectoryHandle,
   setDirectoryPermissionState,
   onFileSelection,
@@ -18,6 +18,7 @@ export const FileExplorer = ({
   directoryPermissionState: PermissionState | null;
   directoryHandle: FileSystemDirectoryHandle | null;
   files: Array<{ filename: string; handle: FileSystemFileHandle }>;
+  selectedFileHandle: FileSystemFileHandle | null;
   setDirectoryPermissionState: (
     directoryPermissionState: PermissionState
   ) => void;
@@ -27,8 +28,6 @@ export const FileExplorer = ({
     fileHandle: FileSystemFileHandle
   ) => void;
 }) => {
-  const [selectedFilename, setSelectedFilename] = React.useState<string>('');
-
   const openDirectory = async () => {
     const dirHandle = await window.showDirectoryPicker();
     setDirectoryHandle(dirHandle);
@@ -47,7 +46,6 @@ export const FileExplorer = ({
 
   async function handleOnClick(fileHandle: FileSystemFileHandle) {
     const fileContent = await readFile(fileHandle);
-    setSelectedFilename(fileHandle.name);
     return onFileSelection(fileContent.docUrl, fileHandle);
   }
 
@@ -65,7 +63,7 @@ export const FileExplorer = ({
                 key={file.filename}
                 className={clsx(
                   'truncate px-2 py-1 text-left hover:bg-zinc-950/5',
-                  file.filename === selectedFilename
+                  file.filename === selectedFileHandle?.name
                     ? 'text-purple-500 dark:text-purple-300'
                     : ''
                 )}

--- a/src/renderer/src/filesystem/index.ts
+++ b/src/renderer/src/filesystem/index.ts
@@ -1,5 +1,13 @@
 export * from './io';
+
 export {
   DirectoryContext,
   DirectoryProvider,
 } from './directoryHandles/context';
+
+export {
+  SelectedFileContext,
+  SelectedFileProvider,
+} from './selectedFile/context';
+
+export { type FileInfo } from './selectedFile/types';

--- a/src/renderer/src/filesystem/selectedFile/context.tsx
+++ b/src/renderer/src/filesystem/selectedFile/context.tsx
@@ -1,0 +1,71 @@
+import { createContext, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { FileInfo } from './types';
+import {
+  openDB,
+  clearAndInsertOne,
+  get as getFromDB,
+  clearAll,
+} from './database';
+import { isValidAutomergeUrl } from '@automerge/automerge-repo';
+
+type SelectedFileContextType = {
+  selectedFileInfo: FileInfo | null;
+  setSelectedFileInfo: (file: FileInfo) => Promise<void>;
+  clearFileSelection: () => Promise<void>;
+};
+
+export const SelectedFileContext = createContext<SelectedFileContextType>({
+  selectedFileInfo: null,
+  setSelectedFileInfo: async () => {},
+  clearFileSelection: async () => {},
+});
+
+export const SelectedFileProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [selectedFileInfo, setSelectedFileInfo] = useState<FileInfo | null>(
+    null
+  );
+  const { documentId: automergeUrl } = useParams();
+
+  useEffect(() => {
+    const getFile = async (automergeUrl: FileInfo['automergeUrl']) => {
+      // This is the IndexedDB object store for the selected file info
+      const db = await openDB();
+      const fileInfo = await getFromDB({ automergeUrl, db });
+      setSelectedFileInfo(fileInfo);
+    };
+
+    if (!isValidAutomergeUrl(automergeUrl)) {
+      clearFileSelection();
+    } else {
+      getFile(automergeUrl);
+    }
+  }, [automergeUrl]);
+
+  const persistSelectedFileInfo = async (fileInfo: FileInfo) => {
+    const db = await openDB();
+    await clearAndInsertOne({ fileInfo, db });
+  };
+
+  const clearFileSelection = async () => {
+    const db = await openDB();
+    await clearAll(db);
+  };
+
+  return (
+    <SelectedFileContext.Provider
+      value={{
+        selectedFileInfo,
+        setSelectedFileInfo: persistSelectedFileInfo,
+        clearFileSelection,
+      }}
+    >
+      {children}
+    </SelectedFileContext.Provider>
+  );
+};

--- a/src/renderer/src/filesystem/selectedFile/database.ts
+++ b/src/renderer/src/filesystem/selectedFile/database.ts
@@ -1,0 +1,86 @@
+const dbName = 'file_handles';
+const dbVersion = 1;
+const storeName = 'file_handles';
+
+import { FileInfo } from './types';
+
+export const openDB: () => Promise<IDBDatabase> = () => {
+  const request = window.indexedDB.open(dbName, dbVersion);
+
+  return new Promise((resolve, reject) => {
+    request.onerror = (err) => {
+      return reject(err);
+    };
+
+    // In this case the database already exists and we get the reference to it.
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+
+    // Handle initial DB creation and migrations here.
+    // Then, return the reference to the DB.
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      const objectStore = db.createObjectStore(storeName);
+
+      objectStore.transaction.oncomplete = () => {
+        return resolve(db);
+      };
+
+      objectStore.transaction.onerror = (err) => {
+        return reject(err);
+      };
+
+      objectStore.transaction.onabort = () => {
+        return reject(new Error('Object store transaction aborted'));
+      };
+    };
+  });
+};
+
+// Clears the database and inserts a single file info object.
+export const clearAndInsertOne: (input: {
+  fileInfo: FileInfo;
+  db: IDBDatabase;
+}) => Promise<void> = ({ fileInfo, db }) => {
+  const transaction = db.transaction(storeName, 'readwrite');
+
+  const store = transaction.objectStore(storeName);
+  store.clear();
+  store.add(fileInfo, fileInfo.automergeUrl);
+
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = (err) => reject(err);
+  });
+};
+
+export const clearAll: (db: IDBDatabase) => Promise<void> = (db) => {
+  const request = db
+    .transaction(storeName, 'readwrite')
+    .objectStore(storeName)
+    .clear();
+
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve();
+    request.onerror = (err) => reject(err);
+  });
+};
+
+export const get: (input: {
+  db: IDBDatabase;
+  automergeUrl: FileInfo['automergeUrl'];
+}) => Promise<FileInfo | null> = ({ automergeUrl, db }) => {
+  const request = db
+    .transaction(storeName, 'readwrite')
+    .objectStore(storeName)
+    .get(automergeUrl);
+
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => {
+      resolve((request.result as FileInfo) ?? null);
+    };
+
+    request.onerror = (err) => reject(err);
+  });
+};

--- a/src/renderer/src/filesystem/selectedFile/types.ts
+++ b/src/renderer/src/filesystem/selectedFile/types.ts
@@ -1,0 +1,6 @@
+import { AutomergeUrl } from '@automerge/automerge-repo';
+
+export type FileInfo = {
+  automergeUrl: AutomergeUrl;
+  fileHandle: FileSystemFileHandle;
+};


### PR DESCRIPTION
## Description

This PR addresses an issue where the file explorer does not display the selected file (according to the URL).

The way the issue was solved was by adding the selected file (Automerge URL + filesystem handle) as an object in IndexedDB.

1. Every time the user selects a file, we persist the selection in IndexedDB (clearing everything else).
2. Every time the URL changes, we check IndexedDB to see if the file is marked as selected there. If we find it, we put its file handle in the context and eventually make it available to the Explorer component.

## Related Issue

#87 

## Screen Recording

https://github.com/stathismor/flow/assets/4354335/fc392206-a4cf-4243-8e7c-c2f045b4bc42

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
