### PR TITLE
chore: sort imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,11 +11,13 @@ module.exports = {
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
-  plugins: ['react-refresh'],
+  plugins: ['react-refresh', 'simple-import-sort'],
   rules: {
     'react-refresh/only-export-components': [
       'warn',
       { allowConstantExport: true },
     ],
+    'sort-imports': 'off',
+    'simple-import-sort/imports': 'error',
   },
 };

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,8 +1,7 @@
-import { defineConfig, loadEnv } from 'electron-vite';
-
 import react from '@vitejs/plugin-react';
-import wasm from 'vite-plugin-wasm';
+import { defineConfig, loadEnv } from 'electron-vite';
 import topLevelAwait from 'vite-plugin-top-level-await';
+import wasm from 'vite-plugin-wasm';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode);

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
+        "eslint-plugin-simple-import-sort": "^12.1.0",
         "eslint-plugin-storybook": "^0.8.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -11791,6 +11792,15 @@
       "dev": true,
       "peerDependencies": {
         "eslint": ">=7"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.0.tgz",
+      "integrity": "sha512-Y2fqAfC11TcG/WP3TrI1Gi3p3nc8XJyEOJYHyEPEGI/UAgNx6akxxlX74p7SbAQdLcgASKhj8M0GKvH3vq/+ig==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-plugin-storybook": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "eslint-plugin-simple-import-sort": "^12.1.0",
     "eslint-plugin-storybook": "^0.8.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,4 +3,4 @@ export default {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,9 @@
-import { app, BrowserWindow, shell, ipcMain, nativeImage } from 'electron';
 import { release } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { app, BrowserWindow, ipcMain, nativeImage, shell } from 'electron';
+
 import { update } from './update';
 
 globalThis.__filename = fileURLToPath(import.meta.url);

--- a/src/main/update.ts
+++ b/src/main/update.ts
@@ -1,5 +1,6 @@
-import { app, ipcMain } from 'electron';
 import { createRequire } from 'node:module';
+
+import { app, ipcMain } from 'electron';
 import type {
   ProgressInfo,
   UpdateDownloadedEvent,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,6 +1,7 @@
+import './App.css';
+
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
-import './App.css';
 import { Editor } from './pages/Editor/index';
 import { History } from './pages/History/History';
 import { Options } from './pages/Options/Options';

--- a/src/renderer/src/components/actions/Button.stories.tsx
+++ b/src/renderer/src/components/actions/Button.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import type { ComponentProps } from 'react';
 
+import { CheckIcon } from '../icons';
 import { Button } from './Button';
 import { IconButton as IconButtonComponent } from './IconButton';
-import { CheckIcon } from '../icons';
 
 const meta: Meta<typeof Button> = {
   title: 'actions/Button',

--- a/src/renderer/src/components/actions/Button.tsx
+++ b/src/renderer/src/components/actions/Button.tsx
@@ -4,6 +4,7 @@ import {
 } from '@headlessui/react';
 import { clsx } from 'clsx';
 import React from 'react';
+
 import { Link } from './Link';
 
 const styles = {

--- a/src/renderer/src/components/actions/IconButton.tsx
+++ b/src/renderer/src/components/actions/IconButton.tsx
@@ -1,5 +1,6 @@
-import { Button, type ButtonColor } from './Button';
 import type { ReactNode } from 'react';
+
+import { Button, type ButtonColor } from './Button';
 
 export type IconButtonProps = {
   icon: ReactNode;

--- a/src/renderer/src/components/actions/Link.tsx
+++ b/src/renderer/src/components/actions/Link.tsx
@@ -1,7 +1,6 @@
-import { Link as ReactRouterLink, type LinkProps } from 'react-router-dom';
-
 import { DataInteractive as HeadlessDataInteractive } from '@headlessui/react';
 import React from 'react';
+import { Link as ReactRouterLink, type LinkProps } from 'react-router-dom';
 
 export const Link = React.forwardRef(function Link(
   props: LinkProps & React.ComponentPropsWithoutRef<'a'>,

--- a/src/renderer/src/components/dialogs/Dialog.tsx
+++ b/src/renderer/src/components/dialogs/Dialog.tsx
@@ -2,10 +2,10 @@ import {
   Description as HeadlessDescription,
   Dialog as HeadlessDialog,
   DialogPanel as HeadlessDialogPanel,
+  type DialogProps as HeadlessDialogProps,
   DialogTitle as HeadlessDialogTitle,
   Transition as HeadlessTransition,
   TransitionChild as HeadlessTransitionChild,
-  type DialogProps as HeadlessDialogProps,
 } from '@headlessui/react';
 import clsx from 'clsx';
 import type React from 'react';

--- a/src/renderer/src/components/dialogs/Modal.stories.tsx
+++ b/src/renderer/src/components/dialogs/Modal.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import type { ComponentProps } from 'react';
-import { Button } from '../actions/Button';
 
+import { Button } from '../actions/Button';
 import { CheckIcon } from '../icons';
 import { Modal } from './Modal';
 

--- a/src/renderer/src/components/dialogs/Modal.tsx
+++ b/src/renderer/src/components/dialogs/Modal.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+
 import {
   Dialog,
   DialogActions,

--- a/src/renderer/src/components/icons/Branch.tsx
+++ b/src/renderer/src/components/icons/Branch.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const BranchIcon = ({
   color,

--- a/src/renderer/src/components/icons/Check.tsx
+++ b/src/renderer/src/components/icons/Check.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const CheckIcon = ({
   color,

--- a/src/renderer/src/components/icons/ChevronDown.tsx
+++ b/src/renderer/src/components/icons/ChevronDown.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const ChevronDownIcon = ({
   color,

--- a/src/renderer/src/components/icons/CommitHistory.tsx
+++ b/src/renderer/src/components/icons/CommitHistory.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const CommitHistoryIcon = ({
   color,

--- a/src/renderer/src/components/icons/FileDocument.tsx
+++ b/src/renderer/src/components/icons/FileDocument.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const FileDocumentIcon = ({
   color,

--- a/src/renderer/src/components/icons/Folder.tsx
+++ b/src/renderer/src/components/icons/Folder.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const FolderIcon = ({
   color,

--- a/src/renderer/src/components/icons/FormatBold.tsx
+++ b/src/renderer/src/components/icons/FormatBold.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const FormatBoldIcon = ({
   color,

--- a/src/renderer/src/components/icons/FormatHeading.tsx
+++ b/src/renderer/src/components/icons/FormatHeading.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const FormatHeadingIcon = ({
   color,

--- a/src/renderer/src/components/icons/FormatHeadingDropdown.tsx
+++ b/src/renderer/src/components/icons/FormatHeadingDropdown.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE as DEFAULT_HEIGHT } from './constants';
+import { IconProps } from './types';
 
 export const FormatHeadingDropdownIcon = ({
   color,

--- a/src/renderer/src/components/icons/FormatItalic.tsx
+++ b/src/renderer/src/components/icons/FormatItalic.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const FormatItalicIcon = ({
   color,

--- a/src/renderer/src/components/icons/FormatListDropdown.tsx
+++ b/src/renderer/src/components/icons/FormatListDropdown.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE as DEFAULT_HEIGHT } from './constants';
+import { IconProps } from './types';
 
 export const FormatListDropdownIcon = ({
   color,

--- a/src/renderer/src/components/icons/FormatUnderline.tsx
+++ b/src/renderer/src/components/icons/FormatUnderline.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const FormatUnderlineIcon = ({
   color,

--- a/src/renderer/src/components/icons/Home.tsx
+++ b/src/renderer/src/components/icons/Home.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const HomeIcon = ({
   color,

--- a/src/renderer/src/components/icons/Image.tsx
+++ b/src/renderer/src/components/icons/Image.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const ImageIcon = ({
   color,

--- a/src/renderer/src/components/icons/Link.tsx
+++ b/src/renderer/src/components/icons/Link.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const LinkIcon = ({
   color,

--- a/src/renderer/src/components/icons/Moon.tsx
+++ b/src/renderer/src/components/icons/Moon.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const MoonIcon = ({
   color,

--- a/src/renderer/src/components/icons/Options.tsx
+++ b/src/renderer/src/components/icons/Options.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const OptionsIcon = ({
   color,

--- a/src/renderer/src/components/icons/Pen.tsx
+++ b/src/renderer/src/components/icons/Pen.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const PenIcon = ({
   color,

--- a/src/renderer/src/components/icons/Push.tsx
+++ b/src/renderer/src/components/icons/Push.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const PushIcon = ({
   color,

--- a/src/renderer/src/components/icons/Revert.tsx
+++ b/src/renderer/src/components/icons/Revert.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const RevertIcon = ({
   color,

--- a/src/renderer/src/components/icons/Sidebar.tsx
+++ b/src/renderer/src/components/icons/Sidebar.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const SidebarIcon = ({
   color,

--- a/src/renderer/src/components/icons/SidebarOpen.tsx
+++ b/src/renderer/src/components/icons/SidebarOpen.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const SidebarOpenIcon = ({
   color,

--- a/src/renderer/src/components/icons/Sun.tsx
+++ b/src/renderer/src/components/icons/Sun.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const SunIcon = ({
   color,

--- a/src/renderer/src/components/icons/ToolbarToggle.tsx
+++ b/src/renderer/src/components/icons/ToolbarToggle.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE as DEFAULT_HEIGHT } from './constants';
+import { IconProps } from './types';
 
 export const ToolbarToggleIcon = ({
   color,

--- a/src/renderer/src/components/icons/User.tsx
+++ b/src/renderer/src/components/icons/User.tsx
@@ -1,5 +1,5 @@
-import { IconProps } from './types';
 import { DEFAULT_SIZE } from './constants';
+import { IconProps } from './types';
 
 export const UserIcon = ({
   color,

--- a/src/renderer/src/components/inputs/Fieldset.tsx
+++ b/src/renderer/src/components/inputs/Fieldset.tsx
@@ -1,13 +1,13 @@
 import {
   Description as HeadlessDescription,
-  Field as HeadlessField,
-  Fieldset as HeadlessFieldset,
-  Label as HeadlessLabel,
-  Legend as HeadlessLegend,
   type DescriptionProps as HeadlessDescriptionProps,
+  Field as HeadlessField,
   type FieldProps as HeadlessFieldProps,
+  Fieldset as HeadlessFieldset,
   type FieldsetProps as HeadlessFieldsetProps,
+  Label as HeadlessLabel,
   type LabelProps as HeadlessLabelProps,
+  Legend as HeadlessLegend,
   type LegendProps as HeadlessLegendProps,
 } from '@headlessui/react';
 import clsx from 'clsx';

--- a/src/renderer/src/components/inputs/Radio.stories.tsx
+++ b/src/renderer/src/components/inputs/Radio.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import type { ComponentProps } from 'react';
 
-import { RadioGroup, Radio, RadioField } from './Radio';
 import { Label } from './Fieldset';
+import { Radio, RadioField, RadioGroup } from './Radio';
 
 const meta: Meta<typeof Radio> = {
   title: 'inputs/Radio',

--- a/src/renderer/src/components/inputs/Radio.tsx
+++ b/src/renderer/src/components/inputs/Radio.tsx
@@ -1,8 +1,8 @@
 import {
   Field as HeadlessField,
+  type FieldProps as HeadlessFieldProps,
   Radio as HeadlessRadio,
   RadioGroup as HeadlessRadioGroup,
-  type FieldProps as HeadlessFieldProps,
   type RadioGroupProps as HeadlessRadioGroupProps,
   type RadioProps as HeadlessRadioProps,
 } from '@headlessui/react';

--- a/src/renderer/src/components/layout/Layout.tsx
+++ b/src/renderer/src/components/layout/Layout.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
-import { useContext, type ReactNode } from 'react';
+import { type ReactNode, useContext } from 'react';
 
-import { NavBar } from '../navigation/NavBar';
 import { ThemeContext, themes } from '../../personalization/theme';
+import { NavBar } from '../navigation/NavBar';
 
 export const Layout = ({ children }: { children: ReactNode }) => {
   const { theme } = useContext(ThemeContext);

--- a/src/renderer/src/components/navigation/NavBar.stories.tsx
+++ b/src/renderer/src/components/navigation/NavBar.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import type { ComponentProps } from 'react';
 import {
-  withRouter,
-  reactRouterParameters,
   reactRouterOutlets,
+  reactRouterParameters,
+  withRouter,
 } from 'storybook-addon-remix-react-router';
 
 import { NavBar } from './NavBar';

--- a/src/renderer/src/components/navigation/NavBar.test.tsx
+++ b/src/renderer/src/components/navigation/NavBar.test.tsx
@@ -1,5 +1,6 @@
 import { composeStories } from '@storybook/react';
 import { render, screen } from '@testing-library/react';
+
 import * as NavSidebarStories from './NavBar.stories';
 
 const { Default } = composeStories(NavSidebarStories);

--- a/src/renderer/src/components/navigation/NavBar.tsx
+++ b/src/renderer/src/components/navigation/NavBar.tsx
@@ -1,8 +1,8 @@
 import { clsx } from 'clsx';
-import { NavLink, useParams, useLocation } from 'react-router-dom';
+import { NavLink, useLocation, useParams } from 'react-router-dom';
 
-import { BranchIcon, OptionsIcon, PenIcon } from '../icons';
 import { Logo } from '../brand/Logo';
+import { BranchIcon, OptionsIcon, PenIcon } from '../icons';
 import { IconProps } from '../icons/types';
 
 const ICON_SIZE = 32;

--- a/src/renderer/src/filesystem/directoryHandles/context.tsx
+++ b/src/renderer/src/filesystem/directoryHandles/context.tsx
@@ -1,5 +1,6 @@
 import { createContext, useEffect, useState } from 'react';
-import { openDB, getFirst, insertOne } from './database';
+
+import { getFirst, insertOne, openDB } from './database';
 
 type DirectoryContextType = {
   directoryHandle: FileSystemDirectoryHandle | null;

--- a/src/renderer/src/filesystem/io.ts
+++ b/src/renderer/src/filesystem/io.ts
@@ -1,5 +1,6 @@
-import { FileContent } from '../types';
 import { AutomergeUrl } from '@automerge/automerge-repo';
+
+import { FileContent } from '../types';
 import { FILE_EXTENSION } from './constants';
 
 export async function writeFile(

--- a/src/renderer/src/filesystem/selectedFile/context.tsx
+++ b/src/renderer/src/filesystem/selectedFile/context.tsx
@@ -1,14 +1,14 @@
+import { isValidAutomergeUrl } from '@automerge/automerge-repo';
 import { createContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { FileInfo } from './types';
 import {
-  openDB,
+  clearAll,
   clearAndInsertOne,
   get as getFromDB,
-  clearAll,
+  openDB,
 } from './database';
-import { isValidAutomergeUrl } from '@automerge/automerge-repo';
+import { FileInfo } from './types';
 
 type SelectedFileContextType = {
   selectedFileInfo: FileInfo | null;

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App.tsx';
-
-import { DocHandle } from '@automerge/automerge-repo';
 import './index.css';
 
+import { DocHandle } from '@automerge/automerge-repo';
 import { RepoContext } from '@automerge/automerge-repo-react-hooks';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import App from './App.tsx';
 import { repo } from './automerge';
-import { ThemeProvider } from './personalization/theme';
 import { DirectoryProvider } from './filesystem';
+import { ThemeProvider } from './personalization/theme';
 
 declare global {
   interface Window {

--- a/src/renderer/src/pages/Editor/CommitDialog.tsx
+++ b/src/renderer/src/pages/Editor/CommitDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+
 import { Button } from '../../components/actions/Button';
 import { Modal } from '../../components/dialogs/Modal';
 import { CheckIcon } from '../../components/icons/Check';

--- a/src/renderer/src/pages/Editor/DocumentEditor.tsx
+++ b/src/renderer/src/pages/Editor/DocumentEditor.tsx
@@ -11,9 +11,10 @@ import { MarkType, Schema } from 'prosemirror-model';
 import { Command, EditorState, Transaction } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import React, { useEffect, useRef } from 'react';
+
 import { VersionedDocument } from '../../automerge';
-import { CommitDialog } from './CommitDialog';
 import { ActionsBar } from './ActionsBar';
+import { CommitDialog } from './CommitDialog';
 import { EditorToolbar } from './EditorToolbar';
 
 const toggleMarkCommand = (mark: MarkType): Command => {

--- a/src/renderer/src/pages/Editor/EditorToolbar.tsx
+++ b/src/renderer/src/pages/Editor/EditorToolbar.tsx
@@ -1,11 +1,11 @@
 import { IconButton } from '../../components/actions/IconButton';
 import {
   FormatBoldIcon,
-  FormatItalicIcon,
-  LinkIcon,
   FormatHeadingDropdownIcon,
+  FormatItalicIcon,
   FormatListDropdownIcon,
   ImageIcon,
+  LinkIcon,
 } from '../../components/icons';
 
 export const EditorToolbar = () => {

--- a/src/renderer/src/pages/Editor/FileExplorer.tsx
+++ b/src/renderer/src/pages/Editor/FileExplorer.tsx
@@ -1,9 +1,9 @@
-import { clsx } from 'clsx';
 import { AutomergeUrl } from '@automerge/automerge-repo';
+import { clsx } from 'clsx';
 
+import { Button } from '../../components/actions/Button';
 import { FileDocumentIcon, FolderIcon } from '../../components/icons';
 import { SidebarHeading } from '../../components/sidebar/SidebarHeading';
-import { Button } from '../../components/actions/Button';
 import { readFile, removeExtension } from '../../filesystem';
 
 export const FileExplorer = ({

--- a/src/renderer/src/pages/Editor/index.tsx
+++ b/src/renderer/src/pages/Editor/index.tsx
@@ -3,8 +3,8 @@ import {
   DocHandle,
   isValidAutomergeUrl,
 } from '@automerge/automerge-repo';
-import { useEffect, useState, useContext } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useContext, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { VersionedDocument } from '../../automerge';
 import { repo } from '../../automerge/repo';
@@ -12,18 +12,18 @@ import { Button } from '../../components/actions/Button';
 import { Modal } from '../../components/dialogs/Modal';
 import { PenIcon } from '../../components/icons';
 import { PersonalFile } from '../../components/illustrations/PersonalFile';
-import { FileExplorer } from './FileExplorer';
+import { Layout } from '../../components/layout/Layout';
 import {
-  DirectoryContext,
   createNewFile,
-  writeFile,
+  DirectoryContext,
   getFiles,
   SelectedFileContext,
   SelectedFileProvider,
+  writeFile,
 } from '../../filesystem';
-import { DocumentEditor } from './DocumentEditor';
 import { InvalidDocument } from '../History/InvalidDocument/InvalidDocument';
-import { Layout } from '../../components/layout/Layout';
+import { DocumentEditor } from './DocumentEditor';
+import { FileExplorer } from './FileExplorer';
 
 export const Editor = () => {
   return (

--- a/src/renderer/src/pages/History/Document/ChangeLog.tsx
+++ b/src/renderer/src/pages/History/Document/ChangeLog.tsx
@@ -1,11 +1,12 @@
-import clsx from 'clsx';
-import { TimelinePoint } from '../../../components/icons/TimelinePoint';
 import { DecodedChange } from '@automerge/automerge/next';
 import { default as Automerge } from '@automerge/automerge/next';
+import clsx from 'clsx';
 import { useContext } from 'react';
-import { ThemeContext, themes } from '../../../personalization/theme';
-import { isCommit } from '../../../automerge';
+
 import type { Commit } from '../../../automerge';
+import { isCommit } from '../../../automerge';
+import { TimelinePoint } from '../../../components/icons/TimelinePoint';
+import { ThemeContext, themes } from '../../../personalization/theme';
 
 const Commit = ({
   commit,

--- a/src/renderer/src/pages/History/Document/CommitView.tsx
+++ b/src/renderer/src/pages/History/Document/CommitView.tsx
@@ -1,16 +1,15 @@
-import { AutomergeUrl } from '@automerge/automerge-repo';
 import { default as Automerge, view } from '@automerge/automerge/next';
-import React, { useCallback, useEffect } from 'react';
-import type { Commit } from '../../../automerge';
-import { ChangeLog } from './ChangeLog';
-
-import { useDocument } from '@automerge/automerge-repo-react-hooks';
 import { decodeChange, getAllChanges } from '@automerge/automerge/next';
+import { AutomergeUrl } from '@automerge/automerge-repo';
+import { useDocument } from '@automerge/automerge-repo-react-hooks';
+import React, { useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { VersionedDocument, isCommit } from '../../../automerge';
+import type { Commit } from '../../../automerge';
+import { isCommit, VersionedDocument } from '../../../automerge';
 import { CommitHistoryIcon } from '../../../components/icons';
 import { SidebarHeading } from '../../../components/sidebar/SidebarHeading';
+import { ChangeLog } from './ChangeLog';
 
 export const CommitView = ({ documentId }: { documentId: AutomergeUrl }) => {
   const [versionedDocument] = useDocument<VersionedDocument>(documentId);

--- a/src/renderer/src/pages/History/Document/DocumentsHistory.tsx
+++ b/src/renderer/src/pages/History/Document/DocumentsHistory.tsx
@@ -1,15 +1,15 @@
-import { AutomergeUrl } from '@automerge/automerge-repo';
 import { default as Automerge, view } from '@automerge/automerge/next';
-import React, { useCallback, useEffect } from 'react';
-import { ChangeLog } from './ChangeLog';
-import type { Commit } from '../../../automerge';
-
-import { useDocument } from '@automerge/automerge-repo-react-hooks';
 import { decodeChange, getAllChanges } from '@automerge/automerge/next';
+import { AutomergeUrl } from '@automerge/automerge-repo';
+import { useDocument } from '@automerge/automerge-repo-react-hooks';
+import React, { useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { VersionedDocument, isCommit } from '../../../automerge';
+
+import type { Commit } from '../../../automerge';
+import { isCommit, VersionedDocument } from '../../../automerge';
 import { CommitHistoryIcon } from '../../../components/icons';
 import { SidebarHeading } from '../../../components/sidebar/SidebarHeading';
+import { ChangeLog } from './ChangeLog';
 
 export const DocumentsHistory = ({
   documentId,

--- a/src/renderer/src/pages/History/History.tsx
+++ b/src/renderer/src/pages/History/History.tsx
@@ -1,10 +1,11 @@
 import { AutomergeUrl, isValidAutomergeUrl } from '@automerge/automerge-repo';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Layout } from '../../components/layout/Layout';
+
 import { Link } from '../../components/actions/Link';
 import { FolderIcon } from '../../components/icons';
 import { PersonalFile } from '../../components/illustrations/PersonalFile';
+import { Layout } from '../../components/layout/Layout';
 import { SidebarHeading } from '../../components/sidebar/SidebarHeading';
 import { DocumentsHistory } from './Document/DocumentsHistory';
 import { InvalidDocument } from './InvalidDocument/InvalidDocument';

--- a/src/renderer/src/pages/Options/Options.tsx
+++ b/src/renderer/src/pages/Options/Options.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+
 import { Layout } from '../../components/layout/Layout';
 import { ThemeSection } from './ThemeSection';
 

--- a/src/renderer/src/pages/Options/SectionHeader.tsx
+++ b/src/renderer/src/pages/Options/SectionHeader.tsx
@@ -1,5 +1,5 @@
-import { Heading2 } from '../../components/typography/headings/Heading2';
 import { IconProps } from '../../components/icons/types';
+import { Heading2 } from '../../components/typography/headings/Heading2';
 
 type SectionHeaderProps = {
   icon?: React.ComponentType<IconProps>;

--- a/src/renderer/src/pages/Options/ThemeSection.tsx
+++ b/src/renderer/src/pages/Options/ThemeSection.tsx
@@ -1,9 +1,10 @@
-import { SectionHeader } from './SectionHeader';
-import { RadioGroup, Radio, RadioField } from '../../components/inputs/Radio';
-import { Label } from '../../components/inputs/Fieldset';
 import { useContext } from 'react';
-import { themes, ThemeContext } from '../../personalization/theme';
+
 import { MoonIcon, SunIcon } from '../../components/icons';
+import { Label } from '../../components/inputs/Fieldset';
+import { Radio, RadioField, RadioGroup } from '../../components/inputs/Radio';
+import { ThemeContext, themes } from '../../personalization/theme';
+import { SectionHeader } from './SectionHeader';
 
 export const ThemeSection = () => {
   const { theme, setTheme } = useContext(ThemeContext);

--- a/src/renderer/src/personalization/theme/context.tsx
+++ b/src/renderer/src/personalization/theme/context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useState } from 'react';
 
-import { themes, type Theme } from './theme';
+import { type Theme, themes } from './theme';
 
 const getDefaultTheme = () =>
   (localStorage.getItem('theme') ?? themes.light) as Theme;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
 // vite.config.ts
-import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import wasm from 'vite-plugin-wasm';
+import { defineConfig } from 'vite';
 import topLevelAwait from 'vite-plugin-top-level-await';
+import wasm from 'vite-plugin-wasm';
 
 export default defineConfig({
   // process.env definition is needed because of:


### PR DESCRIPTION
## Description

Order the imports uniformly with the `eslint-plugin-simple-import-sort` plugin. This should happen on save, on our editors. If not, we could also add a git hook to check for linting errros.

## Related Issue
[Cite any related issue(s) here]

## Screenshots (_if applicable_)
[Attach screenshots if they help illustrate the changes]

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
