### PR TITLE
Update Headless UI to v2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@automerge/automerge-repo-react-hooks": "1.1.12",
         "@automerge/automerge-repo-storage-indexeddb": "1.1.12",
         "@automerge/prosemirror": "^0.0.12",
-        "@headlessui/react": "2.0.0-alpha.4",
+        "@headlessui/react": "^2.0.4",
         "classnames": "^2.5.1",
         "clsx": "^2.1.1",
         "electron-updater": "^6.1.8",
@@ -2902,21 +2902,21 @@
       "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
     },
     "node_modules/@headlessui/react": {
-      "version": "2.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.0.0-alpha.4.tgz",
-      "integrity": "sha512-spykSTXskDUYjSFhdId97Bqclo1F9Ky2pgLmyNKdV4f7aRDncdc/mjMPx67eEWRN2xQobksaUCcnn5K/AcRXsg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.0.4.tgz",
+      "integrity": "sha512-16d/rOLeYsFsmPlRmXGu8DCBzrWD0zV1Ccx3n73wN87yFu8Y9+X04zflv8EJEt9TAYRyLKOmQXUnOnqQl6NgpA==",
       "dependencies": {
-        "@floating-ui/react": "^0.26.2",
-        "@react-aria/focus": "^3.14.3",
-        "@react-aria/interactions": "3.0.0-nightly.2584",
-        "@tanstack/react-virtual": "3.0.0-beta.60"
+        "@floating-ui/react": "^0.26.13",
+        "@react-aria/focus": "^3.16.2",
+        "@react-aria/interactions": "^3.21.1",
+        "@tanstack/react-virtual": "3.5.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
+        "react": "^18",
+        "react-dom": "^18"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -4326,7 +4326,7 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
-    "node_modules/@react-aria/focus/node_modules/@react-aria/interactions": {
+    "node_modules/@react-aria/interactions": {
       "version": "3.21.3",
       "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.3.tgz",
       "integrity": "sha512-BWIuf4qCs5FreDJ9AguawLVS0lV9UU+sK4CCnbCNNmYqOWY+1+gRXCsnOM32K+oMESBxilAjdHW5n1hsMqYMpA==",
@@ -4340,80 +4340,10 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
-    "node_modules/@react-aria/focus/node_modules/@react-aria/ssr": {
+    "node_modules/@react-aria/ssr": {
       "version": "3.9.4",
       "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.4.tgz",
       "integrity": "sha512-4jmAigVq409qcJvQyuorsmBR4+9r3+JEC60wC+Y0MZV0HCtTmm8D9guYXlJMdx0SSkgj0hHAyFm/HvPNFofCoQ==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/interactions": {
-      "version": "3.0.0-nightly.2584",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.0.0-nightly.2584.tgz",
-      "integrity": "sha512-6DqYQx8XnbCfIen33uLz4kdgevrXLW6aoxsBOTY/Mzq9n0LHzbG/5H87obrOxRNVYh62RcQolo/qfqEpXZ7bVA==",
-      "dependencies": {
-        "@react-aria/ssr": "3.9.1-nightly.4295+f600fdfa2",
-        "@react-aria/utils": "3.0.0-nightly.2584+f600fdfa2",
-        "@react-types/shared": "3.0.0-nightly.2584+f600fdfa2",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/interactions/node_modules/@react-aria/utils": {
-      "version": "3.0.0-nightly.2584",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.0.0-nightly.2584.tgz",
-      "integrity": "sha512-A6NP3Yc9MMA+PiRBMTpMlx5plaiK7ejl3cppdkKiNPHtFmZrzxn6o9WHth4NToqIUkJRWHIrpTK8a/gBgVFPOg==",
-      "dependencies": {
-        "@react-aria/ssr": "3.9.1-nightly.4295+f600fdfa2",
-        "@react-stately/utils": "3.0.0-nightly.2584+f600fdfa2",
-        "@react-types/shared": "3.0.0-nightly.2584+f600fdfa2",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/interactions/node_modules/@react-stately/utils": {
-      "version": "3.0.0-nightly.2584",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.0.0-nightly.2584.tgz",
-      "integrity": "sha512-UOW2P+H3O7goB1mNEIwUdxr28CVHrKKvi+N1CQ0TGDwr+Bp6oIZK2aXE6aQluzgwZ36aRvLPW5dAoovpzTTcQQ==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/interactions/node_modules/@react-types/shared": {
-      "version": "3.0.0-nightly.2584",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.0.0-nightly.2584.tgz",
-      "integrity": "sha512-SVqvg7B3rtzN1ypQni5g6sfpUNf4wODRDtiOalBFSJ02YuaUIr7gXVjafPYIXOC1BkJbZtPun/Pv4mCwNHFNbA==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/interactions/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@react-aria/ssr": {
-      "version": "3.9.1-nightly.4295",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.1-nightly.4295.tgz",
-      "integrity": "sha512-cv0+RaS3LJeZiSJ4pVGqSAyiyL+rieLiR3ctyoU7EwkArY1W7fI3NSkMEbNhHe4YoqqjPy1ZzAcpSA11EceiBg==",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       },
@@ -4434,20 +4364,6 @@
         "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0",
         "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/utils/node_modules/@react-aria/ssr": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.4.tgz",
-      "integrity": "sha512-4jmAigVq409qcJvQyuorsmBR4+9r3+JEC60wC+Y0MZV0HCtTmm8D9guYXlJMdx0SSkgj0hHAyFm/HvPNFofCoQ==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "engines": {
-        "node": ">= 12"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
@@ -6373,24 +6289,25 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.0.0-beta.60",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.60.tgz",
-      "integrity": "sha512-F0wL9+byp7lf/tH6U5LW0ZjBqs+hrMXJrj5xcIGcklI0pggvjzMNW9DdIBcyltPNr6hmHQ0wt8FDGe1n1ZAThA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.5.0.tgz",
+      "integrity": "sha512-rtvo7KwuIvqK9zb0VZ5IL7fiJAEnG+0EiFZz8FUOs+2mhGqdGmjKIaT1XU7Zq0eFqL0jonLlhbayJI/J2SA/Bw==",
       "dependencies": {
-        "@tanstack/virtual-core": "3.0.0-beta.60"
+        "@tanstack/virtual-core": "3.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.0.0-beta.60",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.60.tgz",
-      "integrity": "sha512-QlCdhsV1+JIf0c0U6ge6SQmpwsyAT0oQaOSZk50AtEeAyQl9tQrd6qCHAslxQpgphrfe945abvKG8uYvw3hIGA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.5.0.tgz",
+      "integrity": "sha512-KnPRCkQTyqhanNC0K63GBG3wA8I+D1fQuVnAvcBF8f13akOKeQp1gSbu6f77zCxhEk727iV5oQnbHLYzHrECLg==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@automerge/automerge-repo-react-hooks": "1.1.12",
     "@automerge/automerge-repo-storage-indexeddb": "1.1.12",
     "@automerge/prosemirror": "^0.0.12",
-    "@headlessui/react": "2.0.0-alpha.4",
+    "@headlessui/react": "^2.0.4",
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",
     "electron-updater": "^6.1.8",

--- a/src/renderer/src/components/dialogs/Dialog.tsx
+++ b/src/renderer/src/components/dialogs/Dialog.tsx
@@ -1,15 +1,8 @@
-import {
-  Description as HeadlessDescription,
-  Dialog as HeadlessDialog,
-  DialogPanel as HeadlessDialogPanel,
-  type DialogProps as HeadlessDialogProps,
-  DialogTitle as HeadlessDialogTitle,
-  Transition as HeadlessTransition,
-  TransitionChild as HeadlessTransitionChild,
-} from '@headlessui/react';
+import * as Headless from '@headlessui/react';
 import clsx from 'clsx';
-import type React from 'react';
-import { Fragment } from 'react';
+import React, { Fragment } from 'react';
+
+import { Text } from '../typography/Text';
 
 const sizes = {
   xs: 'sm:max-w-xs',
@@ -23,7 +16,7 @@ const sizes = {
   '5xl': 'sm:max-w-5xl',
 };
 
-export const Dialog = ({
+export function Dialog({
   open,
   onClose,
   size = 'lg',
@@ -32,13 +25,13 @@ export const Dialog = ({
   ...props
 }: {
   size?: keyof typeof sizes;
+  className?: string;
   children: React.ReactNode;
-} & HeadlessDialogProps) => {
+} & Omit<Headless.DialogProps, 'className'>) {
   return (
-    <HeadlessTransition appear as={Fragment} show={open} {...props}>
-      <HeadlessDialog onClose={onClose}>
-        <HeadlessTransitionChild
-          as={Fragment}
+    <Headless.Transition appear show={open} {...props}>
+      <Headless.Dialog onClose={onClose}>
+        <Headless.TransitionChild
           enter="ease-out duration-100"
           enterFrom="opacity-0"
           enterTo="opacity-100"
@@ -47,47 +40,42 @@ export const Dialog = ({
           leaveTo="opacity-0"
         >
           <div className="fixed inset-0 flex w-screen justify-center overflow-y-auto bg-zinc-950/25 px-2 py-2 focus:outline-0 sm:px-6 sm:py-8 lg:px-8 lg:py-16 dark:bg-zinc-950/50" />
-        </HeadlessTransitionChild>
+        </Headless.TransitionChild>
 
-        <HeadlessTransitionChild
-          className="fixed inset-0 w-screen overflow-y-auto pt-6 sm:pt-0"
-          enter="ease-out duration-100"
-          enterFrom="opacity-0 translate-y-12 sm:translate-y-0"
-          enterTo="opacity-100 translate-y-0"
-          leave="ease-in duration-100"
-          leaveFrom="opacity-100 translate-y-0"
-          leaveTo="opacity-0 translate-y-12 sm:translate-y-0"
-        >
+        <div className="fixed inset-0 w-screen overflow-y-auto pt-6 sm:pt-0">
           <div className="grid min-h-full grid-rows-[1fr_auto] justify-items-center sm:grid-rows-[1fr_auto_3fr] sm:p-4">
-            <HeadlessTransitionChild
-              as={HeadlessDialogPanel}
-              className={clsx(
-                className,
-                sizes[size],
-                'row-start-2 w-full min-w-0 rounded-t-3xl bg-white p-[--gutter] shadow-lg ring-1 ring-zinc-950/10 [--gutter:theme(spacing.8)] sm:mb-auto sm:rounded-2xl dark:bg-zinc-900 dark:ring-white/10 forced-colors:outline'
-              )}
+            <Headless.TransitionChild
+              as={Fragment}
               enter="ease-out duration-100"
-              enterFrom="sm:scale-95"
-              enterTo="sm:scale-100"
+              enterFrom="opacity-0 translate-y-12 sm:translate-y-0 sm:scale-95"
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
               leave="ease-in duration-100"
-              leaveFrom="sm:scale-100"
-              leaveTo="sm:scale-100"
+              leaveFrom="opacity-100 translate-y-0"
+              leaveTo="opacity-0 translate-y-12 sm:translate-y-0"
             >
-              {children}
-            </HeadlessTransitionChild>
+              <Headless.DialogPanel
+                className={clsx(
+                  className,
+                  sizes[size],
+                  'row-start-2 w-full min-w-0 bg-white p-[--gutter] shadow-lg ring-1 ring-zinc-950/10 [--gutter:theme(spacing.8)] sm:mb-auto dark:bg-zinc-900 dark:ring-white/10 forced-colors:outline'
+                )}
+              >
+                {children}
+              </Headless.DialogPanel>
+            </Headless.TransitionChild>
           </div>
-        </HeadlessTransitionChild>
-      </HeadlessDialog>
-    </HeadlessTransition>
+        </div>
+      </Headless.Dialog>
+    </Headless.Transition>
   );
-};
+}
 
-export const DialogTitle = ({
+export function DialogTitle({
   className,
   ...props
-}: React.ComponentPropsWithoutRef<'div'>) => {
+}: { className?: string } & Omit<Headless.DialogTitleProps, 'className'>) {
   return (
-    <HeadlessDialogTitle
+    <Headless.DialogTitle
       {...props}
       className={clsx(
         className,
@@ -95,31 +83,35 @@ export const DialogTitle = ({
       )}
     />
   );
-};
+}
 
-export const DialogDescription = ({
+export function DialogDescription({
   className,
   ...props
-}: React.ComponentPropsWithoutRef<'div'>) => {
+}: { className?: string } & Omit<
+  Headless.DescriptionProps<typeof Text>,
+  'className'
+>) {
   return (
-    <HeadlessDescription
+    <Headless.Description
+      as={Text}
       {...props}
-      className={clsx(className, 'mt-2 text-pretty dark:text-white')}
+      className={clsx(className, 'mt-2 text-pretty')}
     />
   );
-};
+}
 
-export const DialogBody = ({
+export function DialogBody({
   className,
   ...props
-}: React.ComponentPropsWithoutRef<'div'>) => {
-  return <div {...props} className={clsx(className, 'mt-6 dark:text-white')} />;
-};
+}: React.ComponentPropsWithoutRef<'div'>) {
+  return <div {...props} className={clsx(className, 'mt-6')} />;
+}
 
-export const DialogActions = ({
+export function DialogActions({
   className,
   ...props
-}: React.ComponentPropsWithoutRef<'div'>) => {
+}: React.ComponentPropsWithoutRef<'div'>) {
   return (
     <div
       {...props}
@@ -129,4 +121,4 @@ export const DialogActions = ({
       )}
     />
   );
-};
+}

--- a/src/renderer/src/components/typography/Paragraph.tsx
+++ b/src/renderer/src/components/typography/Paragraph.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx';
 
 export const classes =
-  'text-base/relaxed text-red text-opacity-90 dark:text-zinc-400';
+  'text-base/relaxed text-black text-opacity-90 dark:text-white dark:text-opacity-90';
 
 export function Paragraph({
   className,

--- a/src/renderer/src/components/typography/Text.tsx
+++ b/src/renderer/src/components/typography/Text.tsx
@@ -1,0 +1,17 @@
+import { clsx } from 'clsx';
+
+export function Text({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<'p'>) {
+  return (
+    <p
+      data-slot="text"
+      {...props}
+      className={clsx(
+        className,
+        'text-base/6 text-zinc-500 sm:text-sm/6 dark:text-zinc-400'
+      )}
+    />
+  );
+}


### PR DESCRIPTION
## Description

This PR updates our Headless-UI dependency and sets it to the latest version (2.0.4 or higher).

As part of the update, we introduce a new `Text` component mostly used for inline text in Catalyst and also the dialog component is updated (the latest Catalyst component was used there to be compliant with Headless v2.0.4).

## Related Issue

https://linear.app/v2-editor/issue/V2-18/upgrade-headless-ui-and-catalyst

## Checklist

- [X] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
