### PR TITLE
Toggle heading blocks using the keyboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "clsx": "^2.1.1",
         "electron-updater": "^6.1.8",
         "prosemirror-commands": "^1.5.2",
+        "prosemirror-inputrules": "^1.4.0",
         "prosemirror-keymap": "^1.2.2",
         "prosemirror-model": "^1.21.0",
         "prosemirror-state": "^1.4.3",
@@ -16865,6 +16866,15 @@
       "integrity": "sha512-hgLcPaakxH8tu6YvVAaILV2tXYsW3rAdDR8WNkeKGcgeMVQg3/TMhPdVoh7iAmfgVjZGtcOSjKiQaoeKjzd2mQ==",
       "dependencies": {
         "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.4.0.tgz",
+      "integrity": "sha512-6ygpPRuTJ2lcOXs9JkefieMst63wVJBgHZGl5QOytN7oSZs3Co/BYbc3Yx9zm9H37Bxw8kVzCnDsihsVsL4yEg==",
+      "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "clsx": "^2.1.1",
     "electron-updater": "^6.1.8",
     "prosemirror-commands": "^1.5.2",
+    "prosemirror-inputrules": "^1.4.0",
     "prosemirror-keymap": "^1.2.2",
     "prosemirror-model": "^1.21.0",
     "prosemirror-state": "^1.4.3",

--- a/src/renderer/src/components/editing/RichTextEditor.tsx
+++ b/src/renderer/src/components/editing/RichTextEditor.tsx
@@ -13,16 +13,15 @@ import { EditorView } from 'prosemirror-view';
 import { useEffect, useRef, useState } from 'react';
 
 import { VersionedDocument } from '../../automerge';
-import { getHeadingLevel } from '../../richText/';
+import { getHeadingLevel, prosemirror } from '../../richText/';
 import {
   BlockElementType,
   blockElementTypes,
 } from '../../richText/constants/blocks';
-import {
-  automergeSchemaAdapter,
-  getCurrentBlockType,
-} from '../../richText/prosemirror';
 import { EditorToolbar } from './EditorToolbar';
+
+const { automergeSchemaAdapter, buildInputRules, getCurrentBlockType } =
+  prosemirror;
 
 const toggleBold = (schema: Schema) => toggleMarkCommand(schema.marks.strong);
 
@@ -62,6 +61,7 @@ export const RichTextEditor = ({
       const editorConfig = {
         schema: autoMirror.schema, // This _must_ be the schema from the AutoMirror
         plugins: [
+          buildInputRules(autoMirror.schema),
           keymap({
             ...baseKeymap,
             'Mod-b': toggleBold(autoMirror.schema),

--- a/src/renderer/src/richText/prosemirror/index.ts
+++ b/src/renderer/src/richText/prosemirror/index.ts
@@ -1,2 +1,3 @@
 export * from './selection';
 export * from './schema';
+export * from './inputRules';

--- a/src/renderer/src/richText/prosemirror/inputRules.ts
+++ b/src/renderer/src/richText/prosemirror/inputRules.ts
@@ -1,0 +1,15 @@
+import { inputRules, textblockTypeInputRule } from 'prosemirror-inputrules';
+import { NodeType, Schema } from 'prosemirror-model';
+
+// Based on https://github.com/ProseMirror/prosemirror-example-setup/blob/master/src/inputrules.ts
+export const headingRule = (nodeType: NodeType, maxLevel: number) => {
+  return textblockTypeInputRule(
+    new RegExp('^(#{1,' + maxLevel + '})\\s$'),
+    nodeType,
+    (match) => ({ level: match[1].length })
+  );
+};
+
+export const buildInputRules = (schema: Schema) => {
+  return inputRules({ rules: [headingRule(schema.nodes.heading, 4)] });
+};


### PR DESCRIPTION
## Description

This PR adds the required input rule to toggle headings using the keyboard (`#`, `##` etc).

## Related Issue

https://linear.app/v2-editor/issue/V2-22/toggle-heading-blocks-from-the-keyboard

## Screenshots (_if applicable_)

https://github.com/stathismor/flow/assets/4354335/1068424b-ea3c-41a4-87d0-a8e7a436b214

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
