### PR TITLE
Write project index file to filesystem

### DIFF
--- a/renderer.d.ts
+++ b/renderer.d.ts
@@ -20,7 +20,9 @@ export type AutomergeRepoNetworkAdapter = {
 };
 
 export type VersionControlAPI = {
-  createProject: (args: { directoryPath: string }) => Promise<VersionControlId>;
+  openOrCreateProject: (args: {
+    directoryPath: string;
+  }) => Promise<VersionControlId>;
   openProject: (args: {
     projectId: VersionControlId;
     directoryPath: string;

--- a/src/modules/version-control/repo/browser/react/context.tsx
+++ b/src/modules/version-control/repo/browser/react/context.tsx
@@ -143,8 +143,8 @@ export const VersionControlProvider = ({
           }
         } else {
           if (isElectron) {
-            // Delegate creating the project to the main process
-            projId = await window.versionControlAPI.createProject({
+            // Delegate opening/creating the project to the main process
+            projId = await window.versionControlAPI.openOrCreateProject({
               directoryPath: directory.path!,
             });
           } else {

--- a/src/modules/version-control/repo/node/index.ts
+++ b/src/modules/version-control/repo/node/index.ts
@@ -1,1 +1,2 @@
 export { setup } from './setup';
+export { openOrCreateProject, openProjectById } from './openOrCreateProject';

--- a/src/modules/version-control/repo/node/openOrCreateProject.ts
+++ b/src/modules/version-control/repo/node/openOrCreateProject.ts
@@ -1,0 +1,197 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+
+import { BrowserWindow } from 'electron';
+
+import type { Filesystem } from '../../../filesystem';
+import { createAdapter as createAutomergeVersionControlAdapter } from '../../adapters/automerge';
+import {
+  createProjectFromFilesystemContent,
+  updateProjectFromFilesystemContent,
+} from '../../commands';
+import { isValidVersionControlId, type VersionControlId } from '../../models';
+import { setup as setupNodeRepo } from './setup';
+
+const openProject = async ({
+  projectId,
+  directoryPath,
+  rendererProcessId,
+  browserWindow,
+  listDirectoryFiles,
+  readFile,
+}: {
+  projectId: VersionControlId;
+  directoryPath: string;
+  rendererProcessId: string;
+  browserWindow: BrowserWindow;
+  listDirectoryFiles: Filesystem['listDirectoryFiles'];
+  readFile: Filesystem['readFile'];
+}): Promise<void> => {
+  // Setup the version control repository
+  const automergeRepo = await setupNodeRepo({
+    processId: 'main',
+    directoryPath: join(directoryPath, '.v2', 'automerge'),
+    renderers: new Map([[rendererProcessId, browserWindow]]),
+  });
+
+  const versionControlRepo =
+    createAutomergeVersionControlAdapter(automergeRepo);
+
+  await updateProjectFromFilesystemContent({
+    createDocument: versionControlRepo.createDocument,
+    listProjectDocuments: versionControlRepo.listProjectDocuments,
+    findDocumentInProject: versionControlRepo.findDocumentInProject,
+    deleteDocumentFromProject: versionControlRepo.deleteDocumentFromProject,
+    listDirectoryFiles: listDirectoryFiles,
+    readFile: readFile,
+  })({ projectId, directoryPath });
+};
+
+const openProjectFromFilesystem = async ({
+  directoryPath,
+  rendererProcessId,
+  browserWindow,
+  listDirectoryFiles,
+  readFile,
+}: {
+  directoryPath: string;
+  rendererProcessId: string;
+  browserWindow: BrowserWindow;
+  listDirectoryFiles: Filesystem['listDirectoryFiles'];
+  readFile: Filesystem['readFile'];
+}): Promise<VersionControlId> => {
+  // Check if the directory exists
+  await fs.access(directoryPath);
+
+  const indexFilePath = join(directoryPath, '.v2', 'index.txt');
+  // The only thing the index file should contain is the project ID.
+  const { content: projectId } = await readFile(indexFilePath);
+
+  if (!projectId || !isValidVersionControlId(projectId)) {
+    throw new Error('Project ID in the filesystem repo is invalid');
+  }
+
+  await openProject({
+    projectId,
+    directoryPath,
+    rendererProcessId,
+    browserWindow,
+    listDirectoryFiles,
+    readFile,
+  });
+
+  return projectId;
+};
+
+export const openProjectById = async ({
+  projectId,
+  directoryPath,
+  rendererProcessId,
+  browserWindow,
+  listDirectoryFiles,
+  readFile,
+}: {
+  projectId: VersionControlId;
+  directoryPath: string;
+  rendererProcessId: string;
+  browserWindow: BrowserWindow;
+  listDirectoryFiles: Filesystem['listDirectoryFiles'];
+  readFile: Filesystem['readFile'];
+}): Promise<void> => {
+  // Check if the directory exists
+  await fs.access(directoryPath);
+
+  const indexFilePath = join(directoryPath, '.v2', 'index.txt');
+  // The only thing the index file should contain is the project ID.
+  const { content: filesystemProjectId } = await readFile(indexFilePath);
+
+  if (!filesystemProjectId || !isValidVersionControlId(filesystemProjectId)) {
+    throw new Error('Project ID in the filesystem repo is invalid');
+  }
+
+  if (filesystemProjectId !== projectId) {
+    throw new Error(
+      'The project ID in the filesystem is different than the one the app is trying to open'
+    );
+  }
+
+  await openProject({
+    projectId,
+    directoryPath,
+    rendererProcessId,
+    browserWindow,
+    listDirectoryFiles,
+    readFile,
+  });
+};
+
+const createNewProject = async ({
+  directoryPath,
+  rendererProcessId,
+  browserWindow,
+  listDirectoryFiles,
+  readFile,
+}: {
+  directoryPath: string;
+  rendererProcessId: string;
+  browserWindow: BrowserWindow;
+  listDirectoryFiles: Filesystem['listDirectoryFiles'];
+  readFile: Filesystem['readFile'];
+}): Promise<VersionControlId> => {
+  // Setup the version control repository
+  const automergeRepo = await setupNodeRepo({
+    processId: 'main',
+    directoryPath: join(directoryPath, '.v2', 'automerge'),
+    renderers: new Map([[rendererProcessId, browserWindow]]),
+  });
+
+  const versionControlRepo =
+    createAutomergeVersionControlAdapter(automergeRepo);
+
+  const projectId = await createProjectFromFilesystemContent({
+    createProject: versionControlRepo.createProject,
+    createDocument: versionControlRepo.createDocument,
+    listDirectoryFiles: listDirectoryFiles,
+    readFile: readFile,
+  })({ directoryPath });
+
+  const indexFilePath = join(directoryPath, '.v2', 'index.txt');
+  await fs.writeFile(indexFilePath, projectId, 'utf8');
+
+  return projectId;
+};
+
+export const openOrCreateProject = async ({
+  directoryPath,
+  rendererProcessId,
+  browserWindow,
+  listDirectoryFiles,
+  readFile,
+}: {
+  directoryPath: string;
+  rendererProcessId: string;
+  browserWindow: BrowserWindow;
+  listDirectoryFiles: Filesystem['listDirectoryFiles'];
+  readFile: Filesystem['readFile'];
+}): Promise<VersionControlId> => {
+  try {
+    const projectId = await openProjectFromFilesystem({
+      directoryPath,
+      rendererProcessId,
+      browserWindow,
+      listDirectoryFiles,
+      readFile,
+    });
+
+    return projectId;
+  } catch (err) {
+    // Directory or index file does not exist; create a new repo & project
+    return createNewProject({
+      directoryPath,
+      rendererProcessId,
+      browserWindow,
+      listDirectoryFiles,
+      readFile,
+    });
+  }
+};

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -39,8 +39,8 @@ contextBridge.exposeInMainWorld('filesystemAPI', {
 } as FilesystemAPI);
 
 contextBridge.exposeInMainWorld('versionControlAPI', {
-  createProject: ({ directoryPath }: { directoryPath: string }) =>
-    ipcRenderer.invoke('create-project', { directoryPath }),
+  openOrCreateProject: ({ directoryPath }: { directoryPath: string }) =>
+    ipcRenderer.invoke('open-or-create-project', { directoryPath }),
   openProject: ({
     projectId,
     directoryPath,


### PR DESCRIPTION
## Description

With this PR, when we create a project in the filesystem repo, we also write the project ID in an `index.txt` file.

We can then use the project ID when opening the project.

Also, the create project command has changed so that it conditionally opens/creates a project depending on the filesystem state.

## Related Issue

https://linear.app/v2-editor/issue/V2-29/use-the-filesystem-as-the-source-of-truth-when-using-electron

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
