### PR TITLE
Implement undo and redo in the editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "clsx": "^2.1.1",
         "electron-updater": "^6.1.8",
         "prosemirror-commands": "^1.5.2",
+        "prosemirror-history": "^1.4.1",
         "prosemirror-inputrules": "^1.4.0",
         "prosemirror-keymap": "^1.2.2",
         "prosemirror-model": "^1.21.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "clsx": "^2.1.1",
     "electron-updater": "^6.1.8",
     "prosemirror-commands": "^1.5.2",
+    "prosemirror-history": "^1.4.1",
     "prosemirror-inputrules": "^1.4.0",
     "prosemirror-keymap": "^1.2.2",
     "prosemirror-model": "^1.21.0",

--- a/src/renderer/src/components/editing/RichTextEditor.tsx
+++ b/src/renderer/src/components/editing/RichTextEditor.tsx
@@ -4,6 +4,7 @@ import {
   baseKeymap,
   setBlockType as setProsemirrorBlockType,
 } from 'prosemirror-commands';
+import { history, redo, undo } from 'prosemirror-history';
 import { keymap } from 'prosemirror-keymap';
 import { Schema } from 'prosemirror-model';
 import { EditorState, Selection, Transaction } from 'prosemirror-state';
@@ -110,6 +111,7 @@ export const RichTextEditor = ({
         schema,
         plugins: [
           buildInputRules(schema),
+          history(),
           keymap({
             ...baseKeymap,
             'Mod-b': toggleStrong(schema),
@@ -118,6 +120,9 @@ export const RichTextEditor = ({
               onSave();
               return true;
             },
+            'Mod-z': undo,
+            'Mod-y': redo,
+            'Shift-Mod-z': redo,
           }),
           linkSelectionPlugin,
           selectionChangePlugin(onSelectionChange(schema)),


### PR DESCRIPTION
## Description

This PR implements undo/redo in the editor using the `prosemirror-history` module.

## Related Issue

https://linear.app/v2-editor/issue/V2-17/implement-undo-when-typing-in-the-editor

## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
