### PR TITLE
Ensure .v2 folder exists before creating the index file

### DIFF
--- a/src/modules/version-control/automerge-repo/node/openOrCreateProject.ts
+++ b/src/modules/version-control/automerge-repo/node/openOrCreateProject.ts
@@ -139,6 +139,8 @@ const createNewProject = async ({
   listDirectoryFiles: Filesystem['listDirectoryFiles'];
   readFile: Filesystem['readFile'];
 }): Promise<VersionControlId> => {
+  await fs.mkdir(join(directoryPath, '.v2'), { recursive: true });
+
   // Setup the version control repository
   const automergeRepo = await setupNodeRepo({
     processId: 'main',
@@ -187,6 +189,7 @@ export const openOrCreateProject = async ({
     return projectId;
   } catch (err) {
     // Directory or index file does not exist; create a new repo & project
+    // TODO: Delete .v2 directory if anything goes wrong.
     return createNewProject({
       directoryPath,
       rendererProcessId,


### PR DESCRIPTION
## Description

This PR addresses a bug where the project index file is not created. The symptom was that the app could not select a file for a newly-created folder+project because it could not find which project it belongs to.

The fix is to ensure that we create the `.v2` directory before both setting up the automerge repo and creating the index file.

## Related Issue

https://linear.app/v2-editor/issue/V2-39/implement-code-blocks-in-the-editor

## Screenshots (_if applicable_)

[Attach screenshots if they help illustrate the changes]

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
