### PR TITLE
feat: escape keystroke closes file modal

### DIFF
--- a/src/renderer/src/components/dialogs/Modal.tsx
+++ b/src/renderer/src/components/dialogs/Modal.tsx
@@ -12,6 +12,7 @@ type ModalProps = {
   title: string;
   description?: string;
   isOpen?: boolean;
+  onClose?: () => void;
   primaryButton?: React.ReactNode;
   secondaryButton?: React.ReactNode;
   children?: React.ReactNode;
@@ -21,17 +22,26 @@ export const Modal = ({
   title,
   description,
   isOpen: isOpenProp = false,
+  onClose,
   primaryButton,
   secondaryButton,
   children,
 }: ModalProps) => {
   const [isOpen, setIsOpen] = useState(isOpenProp);
+
   useEffect(() => {
     setIsOpen(isOpenProp);
   }, [isOpenProp]);
 
+  const handleClose = () => {
+    setIsOpen(false);
+    if (onClose) {
+      onClose();
+    }
+  };
+
   return (
-    <Dialog open={isOpen} onClose={() => {}}>
+    <Dialog open={isOpen} onClose={handleClose}>
       <DialogTitle>{title}</DialogTitle>
       {description && <DialogDescription>{description}</DialogDescription>}
       {children && <DialogBody>{children}</DialogBody>}

--- a/src/renderer/src/pages/editor/index.tsx
+++ b/src/renderer/src/pages/editor/index.tsx
@@ -180,6 +180,10 @@ const EditorIndex = () => {
         <Modal
           isOpen={isDocumentCreationModalOpen}
           title="Give your document a title"
+          onClose={() => {
+            setNewDocTitle('');
+            openCreateDocumentModal(false);
+          }}
           secondaryButton={
             <Button
               variant="plain"


### PR DESCRIPTION
## Description

I found it a bit counter-intuitive that hitting the Escape button does not close the new file modal, so added it.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
