### PR TITLE
feat: increase paragraph bottom margin

### DIFF
--- a/src/modules/rich-text/prosemirror/schema.ts
+++ b/src/modules/rich-text/prosemirror/schema.ts
@@ -16,6 +16,7 @@ import {
   bulletList as bulletListClasses,
   codeBlock as codeBlockClasses,
   orderedList as orderedListClasses,
+  paragraph as paragraphClasses,
 } from '../../../renderer/src/components/editing/blocks';
 import { link as linkClasses } from '../../../renderer/src/components/editing/marks';
 import { classes as heading1Classes } from '../../../renderer/src/components/typography/headings/Heading1';
@@ -25,7 +26,6 @@ import { classes as heading4Classes } from '../../../renderer/src/components/typ
 import { getLinkAttrsFromDomElement, type LinkAttrs } from '../models/link';
 
 // basics
-const pDOM: DOMOutputSpec = ['p', 0];
 const blockquoteDOM: DOMOutputSpec = ['blockquote', 0];
 const hrDOM: DOMOutputSpec = ['hr'];
 
@@ -69,7 +69,7 @@ const schema: MappedSchemaSpec = {
       group: 'block',
       parseDOM: [{ tag: 'p' }],
       toDOM() {
-        return pDOM;
+        return ['p', { class: paragraphClasses }, 0];
       },
     } as NodeSpec,
 

--- a/src/renderer/src/components/editing/blocks/index.ts
+++ b/src/renderer/src/components/editing/blocks/index.ts
@@ -1,6 +1,8 @@
+export const paragraph = 'block text-base leading-7 mb-4';
+
 export const codeBlock =
-  'block text-sm leading-5 p-4 fontMono bg-black/5 dark:bg-white/10';
+  'block text-sm leading-5 p-4 fontMono bg-black/5 dark:bg-white/10 mb-4';
 
-export const bulletList = 'list-disc pl-6';
+export const bulletList = 'list-disc pl-6 mb-4';
 
-export const orderedList = 'list-decimal pl-6';
+export const orderedList = 'list-decimal pl-6 mb-4';

--- a/src/renderer/src/components/typography/headings/Heading1.tsx
+++ b/src/renderer/src/components/typography/headings/Heading1.tsx
@@ -3,7 +3,7 @@ import { clsx } from 'clsx';
 import { HeadingProps } from './types';
 
 export const classes =
-  'font-bold text-4xl text-black dark:text-white text-opacity-90 dark:text-opacity-90';
+  'font-bold text-4xl text-black dark:text-white text-opacity-90 dark:text-opacity-90 mb-4';
 
 export const Heading1 = ({ children, className }: HeadingProps) => (
   <h1 className={clsx(classes, className)}>{children}</h1>

--- a/src/renderer/src/components/typography/headings/Heading2.tsx
+++ b/src/renderer/src/components/typography/headings/Heading2.tsx
@@ -3,7 +3,7 @@ import { clsx } from 'clsx';
 import { HeadingProps } from './types';
 
 export const classes =
-  'font-bold text-2xl text-black dark:text-white text-opacity-90 dark:text-opacity-90';
+  'font-bold text-2xl text-black dark:text-white text-opacity-90 dark:text-opacity-90 mb-4';
 
 export const Heading2 = ({ children, className }: HeadingProps) => (
   <h2 className={clsx(classes, className)}>{children}</h2>

--- a/src/renderer/src/components/typography/headings/Heading3.tsx
+++ b/src/renderer/src/components/typography/headings/Heading3.tsx
@@ -3,7 +3,7 @@ import { clsx } from 'clsx';
 import { HeadingProps } from './types';
 
 export const classes =
-  'font-bold text-lg text-black dark:text-white text-opacity-90 dark:text-opacity-90';
+  'font-bold text-lg text-black dark:text-white text-opacity-90 dark:text-opacity-90 mb-4';
 
 export const Heading3 = ({ children, className }: HeadingProps) => (
   <h3 className={clsx(classes, className)}>{children}</h3>

--- a/src/renderer/src/components/typography/headings/Heading4.tsx
+++ b/src/renderer/src/components/typography/headings/Heading4.tsx
@@ -3,7 +3,7 @@ import { clsx } from 'clsx';
 import { HeadingProps } from './types';
 
 export const classes =
-  'font-bold text-base text-black dark:text-white text-opacity-90 dark:text-opacity-90';
+  'font-bold text-base text-black dark:text-white text-opacity-90 dark:text-opacity-90 mb-4';
 
 export const Heading4 = ({ children, className }: HeadingProps) => (
   <h4 className={clsx(classes, className)}>{children}</h4>

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1,6 +1,4 @@
 :root {
-  line-height: 1.5;
-  font-weight: 400;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -13,6 +11,11 @@ body {
   min-width: 320px;
   min-height: 100vh;
   height: 100vh;
+}
+
+/* Override paragraph styles in prosemirror lists */
+.ProseMirror li p {
+  margin-bottom: 0.25rem;
 }
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
## Description

This PR adds a bottom margin to paragraph (along with some other styles) unless it's inside a list.

This will result in not having to add newlines to visually separate paragraphs and arguably provide us more interoperability with formats such as markdown which care about the document structure and not styles. Having these extra, no-content paragraphs adds noise to the documents generated from our editor.

Admittedly, this approach can be controversial.

Relevant discussion here: https://github.com/jgm/pandoc/issues/7836

## Related Issue

https://linear.app/v2-editor/issue/V2-46/fix-paragraph-spacing-in-the-editor

## Screenshots (_if applicable_)

[Attach screenshots if they help illustrate the changes]

## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
