### PR TITLE
fix: parse link payload span when getting document spans

### DIFF
--- a/src/modules/version-control/models/document.ts
+++ b/src/modules/version-control/models/document.ts
@@ -50,7 +50,14 @@ const isCommittedChange = (
 export const getSpans: (
   document: VersionedDocument
 ) => Array<RichTextDocumentSpan> = (document) => {
-  return Automerge.spans(document, ['content']);
+  const spans = Automerge.spans(document, ['content']);
+  return spans.map((span) => {
+    // Automerge.spans returns the link value stringified. We should probably raise an issue for this.
+    // TODO: Handle JSON parsing failure
+    return span.type === 'text' && typeof span.marks?.link === 'string'
+      ? { ...span, marks: { ...span.marks, link: JSON.parse(span.marks.link) } }
+      : span;
+  });
 };
 
 export const getDocumentAtCommit =


### PR DESCRIPTION
## Description

`Automerge.spans` returns the `link` data stringified. This PR updates our `getSpans` function so that it parses this link data before returning the spans.

#### Before
```
[
  {
    "type": "text",
    "value": "automerge",
    "marks": {
      "link": "{\"href\":\"https://automerge.org\",\"title\":\"automerge\"}"
    }
  }
]
```
#### After
```
[
  {
    "type": "text",
    "value": "automerge",
    "marks": {
      "link": { "href": "https://automerge.org", "title": "automerge" }
    }
  }
]
```

## Related Issue

https://linear.app/v2-editor/issue/V2-49/parse-link-data-after-using-the-spans-api

## Screenshots (_if applicable_)

[Attach screenshots if they help illustrate the changes]

## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
