### PR TITLE
fix: revert parsing link payload span when getting document spans

### DIFF
--- a/src/modules/version-control/models/document.ts
+++ b/src/modules/version-control/models/document.ts
@@ -50,14 +50,7 @@ const isCommittedChange = (
 export const getSpans: (
   document: VersionedDocument
 ) => Array<RichTextDocumentSpan> = (document) => {
-  const spans = Automerge.spans(document, ['content']);
-  return spans.map((span) => {
-    // Automerge.spans returns the link value stringified. We should probably raise an issue for this.
-    // TODO: Handle JSON parsing failure
-    return span.type === 'text' && typeof span.marks?.link === 'string'
-      ? { ...span, marks: { ...span.marks, link: JSON.parse(span.marks.link) } }
-      : span;
-  });
+  return Automerge.spans(document, ['content']);
 };
 
 export const getDocumentAtCommit =


### PR DESCRIPTION
Reverts stathismor/flow#131

Apparently the stringified link payload is the way Automerge is supposed to return spans at the moment, so it's better to revert this change.