### PR TITLE
Fix can-commit state before initial commit and just after committing

### DIFF
--- a/src/modules/version-control/models/document.ts
+++ b/src/modules/version-control/models/document.ts
@@ -179,4 +179,8 @@ export const getSpansString = (document: VersionedDocument) => {
 
 export const convertToStorageFormat = getSpansString;
 
+export const isEmpty = (document: VersionedDocument): boolean => {
+  return document.content === '';
+};
+
 export type DocHandleChangePayload<T> = AutomergeDocHandleChangePayload<T>;

--- a/src/renderer/src/pages/editor/DocumentEditor.tsx
+++ b/src/renderer/src/pages/editor/DocumentEditor.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
+import { SelectedFileContext } from '../../../../modules/editor-state';
 import { ProseMirrorContext } from '../../../../modules/rich-text/react/context';
 import { type VersionedDocumentHandle } from '../../../../modules/version-control';
 import { RichTextEditor } from '../../components/editing/RichTextEditor';
@@ -15,60 +16,29 @@ export const DocumentEditor = ({
   versionedDocumentHandle: VersionedDocumentHandle;
   canCommit: boolean;
   isSidebarOpen: boolean;
-  isCommitDialogOpen?: boolean;
   onSidebarToggle: () => void;
 }) => {
-  const [isCommitting, openCommitDialog] = useState<boolean>(false);
   const [isEditorToolbarOpen, toggleEditorToolbar] = useState<boolean>(false);
   const { view: editorView } = useContext(ProseMirrorContext);
-
-  useEffect(() => {
-    const updateDocTitle = async (docHandle: VersionedDocumentHandle) => {
-      const doc = await docHandle.doc();
-      document.title = `v2 | editing "${doc.title}"`;
-    };
-
-    if (versionedDocumentHandle) {
-      updateDocTitle(versionedDocumentHandle);
-    }
-  }, [versionedDocumentHandle]);
-
-  const commitChanges = (message: string) => {
-    if (!versionedDocumentHandle) return;
-
-    versionedDocumentHandle.change(
-      (doc) => {
-        // this is effectively a no-op, but it triggers a change event
-        // (not) changing the title of the document, as interfering with the
-        // content outside the Prosemirror API will cause loss of formatting
-        // eslint-disable-next-line no-self-assign
-        doc.title = doc.title;
-      },
-      {
-        message,
-        time: new Date().getTime(),
-      }
-    );
-
-    openCommitDialog(false);
-  };
+  const {
+    onOpenCommitDialog,
+    onCloseCommitDialog,
+    isCommitDialogOpen,
+    onCommit,
+  } = useContext(SelectedFileContext);
 
   const handleEditorToolbarToggle = useCallback(() => {
     toggleEditorToolbar(!isEditorToolbarOpen);
     editorView?.focus();
   }, [editorView, isEditorToolbarOpen]);
 
-  const handleSave = useCallback(() => {
-    openCommitDialog(true);
-  }, []);
-
   return (
     <>
       <CommitDialog
-        isOpen={isCommitting}
-        onCancel={() => openCommitDialog(false)}
+        isOpen={isCommitDialogOpen}
+        onCancel={onCloseCommitDialog}
         canCommit={canCommit}
-        onCommit={(message: string) => commitChanges(message)}
+        onCommit={(message: string) => onCommit(message)}
       />
       <div className="relative flex flex-auto flex-col items-stretch overflow-hidden">
         <ActionsBar
@@ -76,11 +46,11 @@ export const DocumentEditor = ({
           onSidebarToggle={onSidebarToggle}
           onEditorToolbarToggle={handleEditorToolbarToggle}
           canCommit={canCommit}
-          onCheckIconClick={handleSave}
+          onCheckIconClick={onOpenCommitDialog}
         />
         <RichTextEditor
           docHandle={versionedDocumentHandle}
-          onSave={handleSave}
+          onSave={onOpenCommitDialog}
           isToolbarOpen={isEditorToolbarOpen}
         />
       </div>


### PR DESCRIPTION
## Description

This PR addresses a bug where the commit action was disabled before the initial commit. Also, it was enabled right after committing, which shouldn't be allowed.

## Related Issue

https://linear.app/v2-editor/issue/V2-59/fix-can-commit-state-when-creating-a-new-file

## Screenshots (_if applicable_)

[Attach screenshots if they help illustrate the changes]

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
