### PR TITLE
feat: improve sidebar empty views

### DIFF
--- a/src/renderer/src/pages/document/sidebar/document-history/DocumentHistory.tsx
+++ b/src/renderer/src/pages/document/sidebar/document-history/DocumentHistory.tsx
@@ -5,6 +5,7 @@ import {
 import { CommitHistoryIcon } from '../../../../components/icons';
 import { SidebarHeading } from '../../../../components/sidebar/SidebarHeading';
 import { ChangeLog } from './ChangeLog';
+import { EmptyView } from './EmptyView';
 
 export type DocumentHistoryPanelProps = {
   commits: (Commit | UncommitedChange)[];
@@ -24,12 +25,16 @@ export const DocumentHistory = ({
           <SidebarHeading icon={CommitHistoryIcon} text="Document History" />
         </div>
       </div>
-      <div className="overflow-auto">
-        <ChangeLog
-          changes={commits}
-          onClick={onCommitClick}
-          selectedCommit={selectedCommit}
-        />
+      <div className="flex h-full flex-col items-stretch overflow-auto">
+        {commits.length > 0 ? (
+          <ChangeLog
+            changes={commits}
+            onClick={onCommitClick}
+            selectedCommit={selectedCommit}
+          />
+        ) : (
+          <EmptyView />
+        )}
       </div>
     </div>
   );

--- a/src/renderer/src/pages/document/sidebar/document-history/EmptyView.tsx
+++ b/src/renderer/src/pages/document/sidebar/document-history/EmptyView.tsx
@@ -1,0 +1,7 @@
+export const EmptyView = () => {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4">
+      <p>No history data</p>
+    </div>
+  );
+};

--- a/src/renderer/src/pages/document/sidebar/document-list-views/recent-projects/EmptyView.tsx
+++ b/src/renderer/src/pages/document/sidebar/document-list-views/recent-projects/EmptyView.tsx
@@ -1,0 +1,33 @@
+import { Button } from '../../../../../components/actions/Button';
+import { FileDocumentIcon, PenIcon } from '../../../../../components/icons';
+
+export const EmptyView = ({
+  onCreateDocumentButtonClick,
+  onOpenDocumentButtonClick,
+}: {
+  onCreateDocumentButtonClick: () => void;
+  onOpenDocumentButtonClick: () => void;
+}) => {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4">
+      <Button
+        onClick={onOpenDocumentButtonClick}
+        variant="solid"
+        color="purple"
+        className="w-64"
+      >
+        <FileDocumentIcon className="mr-1" />
+        Open document
+      </Button>
+      <Button
+        onClick={onCreateDocumentButtonClick}
+        variant="solid"
+        color="purple"
+        className="w-64"
+      >
+        <PenIcon className="mr-1" />
+        Create document
+      </Button>
+    </div>
+  );
+};

--- a/src/renderer/src/pages/document/sidebar/document-list-views/recent-projects/index.tsx
+++ b/src/renderer/src/pages/document/sidebar/document-list-views/recent-projects/index.tsx
@@ -14,6 +14,7 @@ import {
   useOpenDocument,
 } from '../../../../../hooks/single-document-project';
 import { DocumentList } from '../DocumentList';
+import { EmptyView } from './EmptyView';
 
 export const RecentProjects = ({
   onCreateDocument,
@@ -54,7 +55,12 @@ export const RecentProjects = ({
           </div>
           <DocumentList items={items} onSelectItem={selectDocument} />
         </div>
-      ) : null}
+      ) : (
+        <EmptyView
+          onCreateDocumentButtonClick={onCreateDocument}
+          onOpenDocumentButtonClick={handleOpenDocument}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Description

This PR:
- Adds the open-document and create-document buttons in the recent documents empty view
- Adds a "no history data" text to the empty history view

## Related Issue

https://linear.app/v2-editor/issue/V2-80/improve-sidebar-empty-views

## Screenshots (_if applicable_)

<img width="2560" height="1412" alt="Screenshot 2025-08-10 at 11 53 58 AM" src="https://github.com/user-attachments/assets/7df27a39-3e6d-45d9-a9cd-50dd8e3f0601" />

## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
