### PR TITLE
feat: introduce a maximum width to the editor view

### DIFF
--- a/src/renderer/src/components/editing/RichTextEditor.tsx
+++ b/src/renderer/src/components/editing/RichTextEditor.tsx
@@ -344,7 +344,7 @@ export const RichTextEditor = ({
 
   return (
     <>
-      <div className="flex flex-auto overflow-auto p-4 outline-none">
+      <div className="flex flex-auto p-4 outline-none">
         <div className="flex-auto" id="editor" ref={editorRoot} />
       </div>
 

--- a/src/renderer/src/pages/document/main/editor/DocumentEditor.tsx
+++ b/src/renderer/src/pages/document/main/editor/DocumentEditor.tsx
@@ -29,19 +29,26 @@ export const DocumentEditor = () => {
   }
 
   return (
-    <div className="relative flex flex-auto flex-col items-stretch overflow-hidden">
-      <ActionsBar
-        isSidebarOpen={isSidebarOpen}
-        onSidebarToggle={toggleSidebar}
-        onEditorToolbarToggle={handleEditorToolbarToggle}
-        canCommit={canCommit}
-        onCheckIconClick={onOpenCommitDialog}
-      />
-      <RichTextEditor
-        docHandle={versionedDocumentHandle}
-        onSave={onOpenCommitDialog}
-        isToolbarOpen={isEditorToolbarOpen}
-      />
+    <div className="relative flex flex-auto flex-col items-center overflow-hidden">
+      <div className="w-full">
+        <ActionsBar
+          isSidebarOpen={isSidebarOpen}
+          onSidebarToggle={toggleSidebar}
+          onEditorToolbarToggle={handleEditorToolbarToggle}
+          canCommit={canCommit}
+          onCheckIconClick={onOpenCommitDialog}
+        />
+      </div>
+
+      <div className="flex w-full flex-auto flex-col items-center overflow-auto">
+        <div className="flex w-full max-w-6xl flex-col">
+          <RichTextEditor
+            docHandle={versionedDocumentHandle}
+            onSave={onOpenCommitDialog}
+            isToolbarOpen={isEditorToolbarOpen}
+          />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/renderer/src/pages/document/main/history/DocumentHistoricalView.tsx
+++ b/src/renderer/src/pages/document/main/history/DocumentHistoricalView.tsx
@@ -217,34 +217,48 @@ export const DocumentHistoricalView = () => {
   }
 
   return (
-    <div className="flex flex-auto flex-col items-stretch overflow-auto outline-none">
-      <ActionsBar
-        isSidebarOpen={isSidebarOpen}
-        onSidebarToggle={toggleSidebar}
-        // TODO: Implement revert functionality
-        onRevertIconClick={() => {}}
-        title={viewTitle}
-        canShowDiff={
-          !selectedCommitIndex || !isInitialChange(selectedCommitIndex, commits)
-        }
-        showDiff={showDiffInHistoryView}
-        onSetShowDiffChecked={handleSetShowDiffInHistoryView}
-        diffWith={getDecodedDiffParam()}
-        history={
-          selectedCommitIndex ? commits.slice(selectedCommitIndex + 1) : commits
-        }
-        onDiffCommitSelect={handleDiffCommitSelect}
-        canCommit={canCommit}
-        lastChangeIsCommitAndSelected={Boolean(
-          selectedCommitIndex === 0 && isCommit(commits[selectedCommitIndex])
-        )}
-        uncommittedChangesSelected={Boolean(
-          selectedCommitIndex === 0 && !isCommit(commits[selectedCommitIndex])
-        )}
-        onCommitIconClick={onOpenCommitDialog}
-        onEditIconClick={handleEditClick}
-      />
-      {diffProps ? <ReadOnlyView {...diffProps} /> : <ReadOnlyView doc={doc} />}
+    <div className="flex flex-auto flex-col items-center">
+      <div className="w-full">
+        <ActionsBar
+          isSidebarOpen={isSidebarOpen}
+          onSidebarToggle={toggleSidebar}
+          // TODO: Implement revert functionality
+          onRevertIconClick={() => {}}
+          title={viewTitle}
+          canShowDiff={
+            !selectedCommitIndex ||
+            !isInitialChange(selectedCommitIndex, commits)
+          }
+          showDiff={showDiffInHistoryView}
+          onSetShowDiffChecked={handleSetShowDiffInHistoryView}
+          diffWith={getDecodedDiffParam()}
+          history={
+            selectedCommitIndex
+              ? commits.slice(selectedCommitIndex + 1)
+              : commits
+          }
+          onDiffCommitSelect={handleDiffCommitSelect}
+          canCommit={canCommit}
+          lastChangeIsCommitAndSelected={Boolean(
+            selectedCommitIndex === 0 && isCommit(commits[selectedCommitIndex])
+          )}
+          uncommittedChangesSelected={Boolean(
+            selectedCommitIndex === 0 && !isCommit(commits[selectedCommitIndex])
+          )}
+          onCommitIconClick={onOpenCommitDialog}
+          onEditIconClick={handleEditClick}
+        />
+      </div>
+
+      <div className="flex w-full flex-auto flex-col items-center overflow-auto">
+        <div className="flex w-full max-w-6xl flex-col">
+          {diffProps ? (
+            <ReadOnlyView {...diffProps} />
+          ) : (
+            <ReadOnlyView doc={doc} />
+          )}
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Description

This PR introduces a maximum width to the editor view (`72rem (1152px)`).

## Related Issue

https://linear.app/v2-editor/issue/V2-81/introduce-a-max-width-in-the-document-editor

## Screenshots (_if applicable_)

### Before

<img width="2560" height="1412" alt="Screenshot 2025-08-10 at 1 06 35 PM" src="https://github.com/user-attachments/assets/91cc7783-847d-4106-989f-8fd0c23d0a9c" />

### After

<img width="2560" height="1416" alt="Screenshot 2025-08-10 at 1 06 07 PM" src="https://github.com/user-attachments/assets/1b231e23-4b9d-4262-b6e0-6e6deb8b8f5a" />

## Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
