### PR TITLE
feat: reduce max width in the editor

### DIFF
--- a/src/renderer/src/pages/document/main/editor/DocumentEditor.tsx
+++ b/src/renderer/src/pages/document/main/editor/DocumentEditor.tsx
@@ -41,7 +41,7 @@ export const DocumentEditor = () => {
       </div>
 
       <div className="flex w-full flex-auto flex-col items-center overflow-auto">
-        <div className="flex w-full max-w-6xl flex-col">
+        <div className="flex w-full max-w-3xl flex-col">
           <RichTextEditor
             docHandle={versionedDocumentHandle}
             onSave={onOpenCommitDialog}

--- a/src/renderer/src/pages/document/main/history/DocumentHistoricalView.tsx
+++ b/src/renderer/src/pages/document/main/history/DocumentHistoricalView.tsx
@@ -251,7 +251,7 @@ export const DocumentHistoricalView = () => {
       </div>
 
       <div className="flex w-full flex-auto flex-col items-center overflow-auto">
-        <div className="flex w-full max-w-6xl flex-col">
+        <div className="flex w-full max-w-3xl flex-col">
           {diffProps ? (
             <ReadOnlyView {...diffProps} />
           ) : (


### PR DESCRIPTION
## Description

Reduces the editor's max width to `48rem (768px)`.

## Related Issue

https://linear.app/v2-editor/issue/V2-83/reduce-max-width-in-the-editor

## Screenshots (_if applicable_)

[Attach screenshots if they help illustrate the changes]

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
