### PR TITLE
feat: open links in the default browser in history (read-only) view

### DIFF
--- a/src/modules/domain/rich-text/prosemirror/index.ts
+++ b/src/modules/domain/rich-text/prosemirror/index.ts
@@ -7,3 +7,4 @@ export * from './diff';
 export * from './json';
 export * from './markdown';
 export * from './notes';
+export * from './links';

--- a/src/modules/domain/rich-text/prosemirror/links/index.ts
+++ b/src/modules/domain/rich-text/prosemirror/links/index.ts
@@ -1,0 +1,1 @@
+export * from './open-link-plugin';

--- a/src/modules/domain/rich-text/prosemirror/links/open-link-plugin.ts
+++ b/src/modules/domain/rich-text/prosemirror/links/open-link-plugin.ts
@@ -1,0 +1,30 @@
+import { Plugin } from 'prosemirror-state';
+
+import { getLinkAttrsFromDomElement } from '../../models/link';
+
+export const openExternalLinkPlugin = (
+  openExternalLink: (url: string) => void
+) =>
+  new Plugin({
+    props: {
+      handleDOMEvents: {
+        // handleDOMEvents.click gets the raw MouseEvent before ProseMirror’s internal handlers.
+        // This means preventDefault() actually stops the browser’s navigation in Electron.
+        // This is why we use it instead of handleClick.
+        click: (_, ev) => {
+          const linkAttrs = getLinkAttrsFromDomElement(
+            ev.target as HTMLElement
+          );
+
+          if (linkAttrs.href) {
+            ev.preventDefault();
+            ev.stopPropagation();
+            openExternalLink(linkAttrs.href);
+            return true;
+          }
+
+          return false;
+        },
+      },
+    },
+  });

--- a/src/renderer/src/pages/document/main/history/ReadOnlyView.tsx
+++ b/src/renderer/src/pages/document/main/history/ReadOnlyView.tsx
@@ -9,14 +9,20 @@ import {
   type VersionedDocument,
 } from '../../../../../../modules/domain/rich-text';
 import { ProseMirrorContext } from '../../../../../../modules/domain/rich-text/react/context';
+import { ElectronContext } from '../../../../../../modules/infrastructure/cross-platform';
 import {
   diffDelete,
   diffInsert,
   diffModify,
 } from '../../../../components/editing/marks';
 
-const { automergeSchemaAdapter, diffPlugin, notesPlugin, numberNotes } =
-  prosemirror;
+const {
+  automergeSchemaAdapter,
+  diffPlugin,
+  notesPlugin,
+  numberNotes,
+  openExternalLinkPlugin,
+} = prosemirror;
 
 export type DiffViewProps = {
   docBefore: VersionedDocument;
@@ -45,6 +51,7 @@ const isSingleDocViewProps = (
 type ReadOnlyViewProps = DiffViewProps | SingleDocViewProps;
 
 export const ReadOnlyView = (props: ReadOnlyViewProps) => {
+  const { openExternalLink } = useContext(ElectronContext);
   const editorRoot = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const {
@@ -103,7 +110,11 @@ export const ReadOnlyView = (props: ReadOnlyViewProps) => {
       const state = EditorState.create({
         schema,
         doc: pmDoc,
-        plugins: [diffPlugin({ decorations }), notesPlugin()],
+        plugins: [
+          openExternalLinkPlugin(openExternalLink),
+          diffPlugin({ decorations }),
+          notesPlugin(),
+        ],
       });
 
       numberNotes(state, viewRef.current.dispatch, viewRef.current);
@@ -137,7 +148,7 @@ export const ReadOnlyView = (props: ReadOnlyViewProps) => {
       const state = EditorState.create({
         schema,
         doc: pmDoc,
-        plugins: [notesPlugin()],
+        plugins: [openExternalLinkPlugin(openExternalLink), notesPlugin()],
       });
 
       numberNotes(state, viewRef.current.dispatch, viewRef.current);


### PR DESCRIPTION
## Description

This PR updates how link navigation is handled in the history (editor read-only) view.

It instructs the app to open the link in the default browser instead of the Electron renderer window itself.

## Related Issue

https://linear.app/v2-editor/issue/V2-85/open-links-using-the-default-browser-in-history-view

## Screenshots (_if applicable_)

https://github.com/user-attachments/assets/3bb83005-116a-4162-9e0c-68f223ddd5d7

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
