### PR TITLE
Hide pdf export from command palette

### DIFF
--- a/src/renderer/src/pages/document/command-palette/index.tsx
+++ b/src/renderer/src/pages/document/command-palette/index.tsx
@@ -45,7 +45,7 @@ export const DocumentCommandPalette = ({
       ? handleDocumentSelectionInMultiDocumentProject
       : handleDocumentSelectionInSingleDocumentProject;
 
-  const { exportToText, exportToBinary, exportToPDF } = useExport();
+  const { exportToText, exportToBinary } = useExport();
 
   const singleDocumentProjectActions = [
     {
@@ -94,11 +94,6 @@ export const DocumentCommandPalette = ({
                   onActionSelection: exportToBinary(
                     richTextRepresentations.DOCX
                   ),
-                },
-                {
-                  name: 'Export to PDF',
-                  shortcut: 'P',
-                  onActionSelection: exportToPDF,
                 },
                 {
                   name: 'Export to Pandoc',


### PR DESCRIPTION
## Description

PDF export has an issue with pagination as can be seen in the attached screenshot.

With this PR we remove the PDF export option until we figure out a solution to the issue.

## Screenshots (_if applicable_)

<img width="796" height="791" alt="Screenshot 2025-09-18 at 8 44 45 AM" src="https://github.com/user-attachments/assets/da27cfe6-e65f-43a1-9800-ac92744e4cf1" />

## Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's coding standards
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
