### PR TITLE
Add placeholder text when the editor is empty

### DIFF
--- a/src/modules/domain/rich-text/prosemirror/index.ts
+++ b/src/modules/domain/rich-text/prosemirror/index.ts
@@ -8,3 +8,4 @@ export * from './json';
 export * from './markdown';
 export * from './notes';
 export * from './links';
+export * from './placeholder';

--- a/src/modules/domain/rich-text/prosemirror/placeholder/index.ts
+++ b/src/modules/domain/rich-text/prosemirror/placeholder/index.ts
@@ -1,0 +1,1 @@
+export * from './plugin';

--- a/src/modules/domain/rich-text/prosemirror/placeholder/plugin.ts
+++ b/src/modules/domain/rich-text/prosemirror/placeholder/plugin.ts
@@ -1,0 +1,31 @@
+import { Plugin, PluginKey } from 'prosemirror-state';
+import { Decoration, DecorationSet } from 'prosemirror-view';
+
+const pluginKey = new PluginKey('placeholder');
+
+export const placeholderPlugin = (placeholderText: string) => {
+  return new Plugin({
+    key: pluginKey,
+    props: {
+      decorations(state) {
+        const doc = state.doc;
+
+        if (
+          doc.childCount === 1 &&
+          doc.firstChild?.isTextblock &&
+          doc.firstChild.content.size === 0
+        ) {
+          const placeholderElement = document.createElement('span');
+          placeholderElement.textContent = placeholderText;
+
+          placeholderElement.className =
+            'text-gray-400 pointer-events-none select-none';
+
+          return DecorationSet.create(doc, [
+            Decoration.widget(1, placeholderElement),
+          ]);
+        }
+      },
+    },
+  });
+};

--- a/src/renderer/src/components/editing/RichTextEditor.tsx
+++ b/src/renderer/src/components/editing/RichTextEditor.tsx
@@ -55,6 +55,7 @@ const {
   insertNote,
   notesPlugin,
   numberNotes,
+  placeholderPlugin,
 } = prosemirror;
 
 type RichTextEditorProps = {
@@ -127,6 +128,7 @@ export const RichTextEditor = ({
 
       const plugins = [
         buildInputRules(schema),
+        placeholderPlugin('Start writing...'),
         ...markdownMarkPlugins(schema),
         pasteMarkdownPlugin(parseMarkdown(schema)),
         notesPlugin(),


### PR DESCRIPTION
## Description

With this PR a placeholder (`Start writing...`) is displayed when the editor view is empty.

## Related Issue

Closes #202 

## Screenshots (_if applicable_)

<img width="2560" height="794" alt="Screenshot 2025-09-19 at 3 02 12 PM" src="https://github.com/user-attachments/assets/f53bb642-66da-4648-a53a-7fbaed2304c2" />

## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
