### PR TITLE
fix: make Linux artifacts executable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,9 +142,6 @@ jobs:
             bin/*.rpm
             bin/*.tar.gz
             bin/latest-linux.yml
-      - name: Make AppImage executable
-        if: matrix.os == 'ubuntu-latest'
-        run: chmod +x ./bin/*.AppImage
 
   release:
     needs: [versioning, build]
@@ -170,6 +167,8 @@ jobs:
           cp ./artifacts/macos-build-*/* ./release-assets/macos/ || true
           cp ./artifacts/windows-build-*/* ./release-assets/windows/ || true
           cp ./artifacts/linux-build-*/* ./release-assets/linux/ || true
+      - name: Make AppImage executable
+        run: chmod +x ./release-assets/linux/*.AppImage || true
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Description

AppImage files are not executable, let's make them.

## Related Issue

[Cite any related issue(s) here]

## Screenshots (_if applicable_)

[Attach screenshots if they help illustrate the changes]

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
