### PR TITLE
feat: enable clearing application data from the command palette

### DIFF
--- a/renderer.d.ts
+++ b/renderer.d.ts
@@ -25,6 +25,7 @@ export type ElectronAPI = {
   onReceiveProcessId: (callback: (processId: string) => void) => IpcRenderer;
   sendCurrentDocumentId: (id: VersionControlId) => void;
   openExternalLink: (url: string) => void;
+  clearWebStorage: () => Promise<void>;
 };
 
 export type UnregisterListenerFn = () => void;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -392,3 +392,8 @@ ipcMain.handle('open-win', (_, arg) => {
     childWindow.loadFile(indexHtml, { hash: arg });
   }
 });
+
+ipcMain.handle('clear-web-storage', async (event) => {
+  const ses = event.sender.session;
+  await ses.clearStorageData();
+});

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 import {
+  type ElectronAPI,
   type MultiDocumentProjectAPI,
   type OsEventsAPI,
   type SingleDocumentProjectAPI,
@@ -37,7 +38,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.send('current-document-id', id),
   openExternalLink: (url: string) =>
     ipcRenderer.send('open-external-link', url),
-});
+  clearWebStorage: () => ipcRenderer.invoke('clear-web-storage'),
+} as ElectronAPI);
 
 contextBridge.exposeInMainWorld('automergeRepoNetworkAdapter', {
   sendRendererProcessMessage: (

--- a/src/renderer/src/components/dialogs/command-palette/CommandPalette.tsx
+++ b/src/renderer/src/components/dialogs/command-palette/CommandPalette.tsx
@@ -32,12 +32,13 @@ function isDocumentOption(
   return false;
 }
 
-type DocumentOption = {
+export type DocumentOption = {
   id?: string;
   title: string;
   onDocumentSelection: () => void;
 };
-type ActionOption = {
+
+export type ActionOption = {
   name: string;
   shortcut?: string;
   onActionSelection: () => void;

--- a/src/renderer/src/hooks/index.ts
+++ b/src/renderer/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './use-document-list';
 export * from './use-key-bindings';
 export * from './use-navigate-to-document';
 export * from './use-export';
+export * from './use-clear-web-storage';

--- a/src/renderer/src/hooks/use-clear-web-storage.ts
+++ b/src/renderer/src/hooks/use-clear-web-storage.ts
@@ -1,0 +1,12 @@
+import { useNavigate } from 'react-router';
+
+export const useClearWebStorage = () => {
+  const navigate = useNavigate();
+
+  const clearWebStorage = async () => {
+    await window.electronAPI.clearWebStorage();
+    navigate('/', { replace: true });
+  };
+
+  return clearWebStorage;
+};


### PR DESCRIPTION
## Description

Enable clearing application data without accessing developer tools (from the Command Palette). Only available in the Electron (not browser) version for now.

## Related Issue

Closes #205 

## Screenshots (_if applicable_)

https://github.com/user-attachments/assets/920b39ee-df30-475d-ab86-929542066442

## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
