### PR TITLE
feat: add file associations config for Windows and Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,18 @@
             "ia32"
           ]
         }
-      ]
+      ],
+      "fileAssociations": [
+        {
+          "ext": "v2",
+          "name": "v2",
+          "description": "v2 Document",
+          "icon": "public/icon.ico"
+        }
+      ],
+      "nsis": {
+        "perMachine": true
+      }
     },
     "linux": {
       "icon": "public/icons/icon",
@@ -115,6 +126,12 @@
             "x64",
             "arm64"
           ]
+        }
+      ],
+      "fileAssociations": [
+        {
+          "ext": "v2",
+          "name": "v2"
         }
       ]
     },


### PR DESCRIPTION
## Description

Associates `.v2` files with the editor in Windows and Linux.

## Related Issue

#209 

## Screenshots (_if applicable_)

[Attach screenshots if they help illustrate the changes]

## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
