### PR TITLE
feat: update title bar on theme changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "debounce": "^2.2.0",
     "effect": "^3.15.3",
     "electron-log": "^5.4.3",
+    "electron-store": "^10.1.0",
     "electron-updater": "^6.6.2",
     "fast-deep-equal": "^3.1.3",
     "html2pdf.js": "^0.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       electron-log:
         specifier: ^5.4.3
         version: 5.4.3
+      electron-store:
+        specifier: ^10.1.0
+        version: 10.1.0
       electron-updater:
         specifier: ^6.6.2
         version: 6.6.2
@@ -1750,6 +1753,14 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
@@ -1757,6 +1768,9 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -1859,6 +1873,9 @@ packages:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
     engines: {node: '>= 4.5.0'}
     hasBin: true
+
+  atomically@2.0.3:
+    resolution: {integrity: sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==}
 
   autoprefixer@10.4.21:
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
@@ -2170,6 +2187,10 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  conf@14.0.0:
+    resolution: {integrity: sha512-L6BuueHTRuJHQvQVc6YXYZRtN5vJUtOdCTLn0tRYYV5azfbAFcPghB5zEE40mVrV6w7slMTqUfkDomutIK14fw==}
+    engines: {node: '>=20'}
+
   config-file-ts@0.2.8-rc1:
     resolution: {integrity: sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==}
 
@@ -2231,6 +2252,10 @@ packages:
   data-urls@3.0.2:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
+
+  debounce-fn@6.0.0:
+    resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
+    engines: {node: '>=18'}
 
   debounce@2.2.0:
     resolution: {integrity: sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==}
@@ -2361,6 +2386,10 @@ packages:
   dompurify@3.2.6:
     resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
 
+  dot-prop@9.0.0:
+    resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
+    engines: {node: '>=18'}
+
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
     engines: {node: '>=12'}
@@ -2398,6 +2427,10 @@ packages:
 
   electron-publish@26.0.11:
     resolution: {integrity: sha512-a8QRH0rAPIWH9WyyS5LbNvW9Ark6qe63/LqDB7vu2JXYpi0Gma5Q60Dh4tmTqhOBQt0xsrzD8qE7C+D7j+B24A==}
+
+  electron-store@10.1.0:
+    resolution: {integrity: sha512-oL8bRy7pVCLpwhmXy05Rh/L6O93+k9t6dqSw0+MckIc3OmCTZm6Mp04Q4f/J0rtu84Ky6ywkR8ivtGOmrq+16w==}
+    engines: {node: '>=20'}
 
   electron-to-chromium@1.5.157:
     resolution: {integrity: sha512-/0ybgsQd1muo8QlnuTpKwtl0oX5YMlUGbm8xyqgDU00motRkKFFbUJySAQBWcY79rVqNLWIWa87BGVGClwAB2w==}
@@ -2448,6 +2481,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -2652,6 +2689,9 @@ packages:
 
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -3342,6 +3382,12 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.1:
+    resolution: {integrity: sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -3509,6 +3555,10 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
@@ -4124,6 +4174,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
@@ -4443,6 +4497,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  stubborn-fs@1.2.5:
+    resolution: {integrity: sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==}
+
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4654,6 +4711,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -4814,6 +4875,9 @@ packages:
   whatwg-url@11.0.0:
     resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
     engines: {node: '>=12'}
+
+  when-exit@2.1.4:
+    resolution: {integrity: sha512-4rnvd3A1t16PWzrBUcSDZqcAmsUIy4minDXT/CZ8F2mVDgd65i4Aalimgz1aQkRGU0iH5eT5+6Rx2TK8o443Pg==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -6622,6 +6686,10 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
       ajv: 6.12.6
@@ -6632,6 +6700,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@4.3.2:
     dependencies:
@@ -6746,6 +6821,11 @@ snapshots:
   at-least-node@1.0.0: {}
 
   atob@2.1.2: {}
+
+  atomically@2.0.3:
+    dependencies:
+      stubborn-fs: 1.2.5
+      when-exit: 2.1.4
 
   autoprefixer@10.4.21(postcss@8.5.3):
     dependencies:
@@ -7127,6 +7207,18 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  conf@14.0.0:
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      atomically: 2.0.3
+      debounce-fn: 6.0.0
+      dot-prop: 9.0.0
+      env-paths: 3.0.0
+      json-schema-typed: 8.0.1
+      semver: 7.7.2
+      uint8array-extras: 1.5.0
+
   config-file-ts@0.2.8-rc1:
     dependencies:
       glob: 10.4.5
@@ -7197,6 +7289,10 @@ snapshots:
       abab: 2.0.6
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
+
+  debounce-fn@6.0.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   debounce@2.2.0: {}
 
@@ -7330,6 +7426,10 @@ snapshots:
       '@types/trusted-types': 2.0.7
     optional: true
 
+  dot-prop@9.0.0:
+    dependencies:
+      type-fest: 4.41.0
+
   dotenv-expand@11.0.7:
     dependencies:
       dotenv: 16.5.0
@@ -7394,6 +7494,11 @@ snapshots:
       mime: 2.6.0
     transitivePeerDependencies:
       - supports-color
+
+  electron-store@10.1.0:
+    dependencies:
+      conf: 14.0.0
+      type-fest: 4.41.0
 
   electron-to-chromium@1.5.157: {}
 
@@ -7462,6 +7567,8 @@ snapshots:
   entities@6.0.0: {}
 
   env-paths@2.2.1: {}
+
+  env-paths@3.0.0: {}
 
   err-code@2.0.3: {}
 
@@ -7722,6 +7829,8 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-sha256@1.3.0: {}
+
+  fast-uri@3.1.0: {}
 
   fastq@1.19.1:
     dependencies:
@@ -8646,6 +8755,10 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.1: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1:
@@ -8817,6 +8930,8 @@ snapshots:
   mime@2.6.0: {}
 
   mimic-fn@2.1.0: {}
+
+  mimic-function@5.0.1: {}
 
   mimic-response@1.0.1: {}
 
@@ -9385,6 +9500,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   requires-port@1.0.0: {}
 
   resedit@1.7.2:
@@ -9737,6 +9854,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  stubborn-fs@1.2.5: {}
+
   sucrase@3.35.0:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
@@ -9978,6 +10097,8 @@ snapshots:
 
   typescript@5.8.3: {}
 
+  uint8array-extras@1.5.0: {}
+
   undici-types@6.21.0: {}
 
   unique-filename@2.0.1:
@@ -10112,6 +10233,8 @@ snapshots:
     dependencies:
       tr46: 3.0.0
       webidl-conversions: 7.0.0
+
+  when-exit@2.1.4: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/renderer.d.ts
+++ b/renderer.d.ts
@@ -21,6 +21,12 @@ import type {
   VersionControlId,
 } from './src/modules/infrastructure/version-control';
 import { type Wasm as WasmAPI } from './src/modules/infrastructure/wasm';
+import {
+  type ResolvedTheme,
+  type Theme,
+} from './src/modules/personalization/theme';
+
+export type UnregisterListenerFn = () => void;
 
 export type ElectronAPI = {
   onReceiveProcessId: (callback: (processId: string) => void) => IpcRenderer;
@@ -35,7 +41,12 @@ export type ElectronAPI = {
   restartToInstallUpdate: () => Promise<void>;
 };
 
-export type UnregisterListenerFn = () => void;
+export type PersonalizationAPI = {
+  setTheme: (theme: Theme) => Promise<void>;
+  getTheme: () => Promise<Theme>;
+  getSystemTheme: () => Promise<Exclude<Theme, 'system'>>;
+  onSystemThemeUpdate: (callback: (theme: ResolvedTheme) => void) => () => void;
+};
 
 export type AutomergeRepoNetworkAdapter = {
   sendRendererProcessMessage: (
@@ -83,6 +94,7 @@ export type OsEventsAPI = {
 declare global {
   interface Window {
     electronAPI: ElectronAPI;
+    personalizationAPI: PersonalizationAPI;
     automergeRepoNetworkAdapter: AutomergeRepoNetworkAdapter;
     filesystemAPI: FilesystemPromiseAPI;
     versionControlAPI: VersionControlAPI;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,8 +36,11 @@ import { createAdapter as createElectronNodeFilesystemAPIAdapter } from '../modu
 import { type RunWasiCLIArgs } from '../modules/infrastructure/wasm';
 import { createAdapter as createNodeWasmAdapter } from '../modules/infrastructure/wasm/adapters/node-wasm';
 import { buildMenu } from './menu';
+import { initializeStore } from './store';
+import { registerThemeIPCHandlers, setSavedOrDefaultTheme } from './theme';
 import { update } from './update';
 
+const store = initializeStore();
 const filesystemAPI = createElectronNodeFilesystemAPIAdapter();
 
 globalThis.__filename = fileURLToPath(import.meta.url);
@@ -340,11 +343,15 @@ async function createWindow() {
   ipcMain.handle('run-wasi-cli-outputing-binary', (_, args: RunWasiCLIArgs) =>
     wasmAPI.runWasiCLIOutputingBinary(args)
   );
+
+  registerThemeIPCHandlers({ store, win });
 }
 
 app.whenReady().then(() => {
   const menu = buildMenu();
   Menu.setApplicationMenu(menu);
+
+  setSavedOrDefaultTheme(store);
 
   createWindow();
 });

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -1,0 +1,22 @@
+import Store from 'electron-store';
+
+import { type Theme, themes } from '../modules/personalization/theme';
+
+export type UserPreferencesStore = Store<UserPreferences>;
+
+export type UserPreferences = {
+  theme: Theme;
+};
+
+const schema = {
+  theme: {
+    type: 'string',
+    enum: [themes.system, themes.light, themes.dark],
+    default: themes.system,
+  },
+};
+
+export const initializeStore = () => {
+  const store = new Store<UserPreferences>({ schema });
+  return store;
+};

--- a/src/main/theme.ts
+++ b/src/main/theme.ts
@@ -1,0 +1,36 @@
+import { BrowserWindow, ipcMain, nativeTheme } from 'electron';
+import Store from 'electron-store';
+
+import { type Theme, themes } from '../modules/personalization';
+import { type UserPreferences } from './store';
+
+export const setSavedOrDefaultTheme = (store: Store<UserPreferences>) => {
+  const savedTheme = store.get('theme', themes.system); // default to system
+  nativeTheme.themeSource = savedTheme;
+};
+
+export const registerThemeIPCHandlers = ({
+  store,
+  win,
+}: {
+  store: Store<UserPreferences>;
+  win: BrowserWindow;
+}) => {
+  ipcMain.on('set-theme', (_, theme: Theme) => {
+    store.set('theme', theme);
+    nativeTheme.themeSource = theme;
+  });
+
+  ipcMain.handle('get-theme', () => store.get('theme'));
+
+  ipcMain.handle('get-system-theme', () =>
+    nativeTheme.shouldUseDarkColors ? themes.dark : themes.light
+  );
+
+  nativeTheme.on('updated', () => {
+    win.webContents.send(
+      'system-theme-update',
+      nativeTheme.shouldUseDarkColors ? themes.dark : themes.light
+    );
+  });
+};

--- a/src/modules/infrastructure/cross-platform/electron-context.tsx
+++ b/src/modules/infrastructure/cross-platform/electron-context.tsx
@@ -46,7 +46,7 @@ export const ElectronProvider = ({
       });
 
     return () => {
-      unsubscribeFromUpdateStateChange();
+      unsubscribeFromUpdateStateChange?.();
     };
   }, []);
 

--- a/src/modules/personalization/browser.ts
+++ b/src/modules/personalization/browser.ts
@@ -1,0 +1,7 @@
+export { ThemeContext, ThemeProvider } from './theme/context.tsx';
+export {
+  FunctionalityConfigContext,
+  FunctionalityConfigProvider,
+} from './functionality-config/context.tsx';
+
+export * from './theme';

--- a/src/modules/personalization/functionality-config/index.ts
+++ b/src/modules/personalization/functionality-config/index.ts
@@ -1,4 +1,0 @@
-export {
-  FunctionalityConfigContext,
-  FunctionalityConfigProvider,
-} from './context.tsx';

--- a/src/modules/personalization/index.ts
+++ b/src/modules/personalization/index.ts
@@ -1,0 +1,1 @@
+export * from './theme';

--- a/src/modules/personalization/theme/context.tsx
+++ b/src/modules/personalization/theme/context.tsx
@@ -1,32 +1,92 @@
-import { createContext, useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
-import { type Theme, themes } from './theme';
+import { ElectronContext } from '../../infrastructure/cross-platform/electron-context';
+import { type ResolvedTheme, type Theme, themes } from './theme';
 
 const getDefaultTheme = () =>
   (localStorage.getItem('theme') ?? themes.light) as Theme;
 
 type ThemeContextType = {
   theme: Theme;
+  resolvedTheme: ResolvedTheme | null; // This will be used if the theme is 'system'
   setTheme: (theme: Theme) => void;
 };
 
 export const ThemeContext = createContext<ThemeContextType>({
   theme: getDefaultTheme(),
+  resolvedTheme: null,
   // This is a placeholder. It will be properly implemented in the provider below.
   setTheme: () => {},
 });
 
+const getSystemTheme = async (isElectron: boolean) => {
+  if (isElectron) {
+    return window.personalizationAPI.getSystemTheme();
+  }
+
+  // Fallback for non-Electron environments (e.g., web)
+  const isDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  return isDarkMode ? themes.dark : themes.light;
+};
+
 export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
   const [theme, setTheme] = useState(getDefaultTheme());
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme | null>(
+    null
+  );
+  const { isElectron } = useContext(ElectronContext);
 
   useEffect(() => {
-    // set the theme in the body element
-    document.body.classList.remove('dark', 'light');
-    document.body.classList.add(theme);
+    const getThemeFromMain = async () => {
+      const themeFromMain = await window.personalizationAPI.getTheme();
+      setTheme(themeFromMain);
+    };
+
+    const unsubscribeFromThemeUpdates =
+      window.personalizationAPI?.onSystemThemeUpdate((newTheme) => {
+        setResolvedTheme(newTheme);
+      });
+
+    if (isElectron) {
+      getThemeFromMain();
+    }
+
+    return () => {
+      unsubscribeFromThemeUpdates?.();
+    };
+  }, [isElectron]);
+
+  useEffect(() => {
+    const updateResolvedTheme = async (newTheme: Theme) => {
+      if (newTheme === themes.system) {
+        const systemTheme = await getSystemTheme(isElectron);
+        setResolvedTheme(systemTheme);
+      } else {
+        setResolvedTheme(newTheme);
+      }
+    };
+
+    updateResolvedTheme(theme);
   }, [theme]);
+
+  useEffect(() => {
+    const updateBodyThemeClass = async (resolvedTheme: ResolvedTheme) => {
+      document.body.classList.remove('dark', 'light');
+      document.body.classList.add(resolvedTheme);
+    };
+
+    if (resolvedTheme) {
+      updateBodyThemeClass(resolvedTheme);
+    }
+  }, [resolvedTheme]);
 
   const handleSetTheme = (theme: Theme) => {
     localStorage.setItem('theme', theme);
+
+    if (isElectron) {
+      window.personalizationAPI.setTheme(theme);
+    }
+
     setTheme(theme);
   };
 
@@ -34,6 +94,7 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
     <ThemeContext.Provider
       value={{
         theme,
+        resolvedTheme,
         setTheme: handleSetTheme,
       }}
     >

--- a/src/modules/personalization/theme/index.ts
+++ b/src/modules/personalization/theme/index.ts
@@ -1,2 +1,1 @@
 export * from './theme.ts';
-export { ThemeContext, ThemeProvider } from './context.tsx';

--- a/src/modules/personalization/theme/theme.ts
+++ b/src/modules/personalization/theme/theme.ts
@@ -1,6 +1,9 @@
 export const themes = {
+  system: 'system',
   light: 'light',
   dark: 'dark',
 } as const;
 
 export type Theme = keyof typeof themes;
+
+export type ResolvedTheme = Exclude<Theme, 'system'>;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,7 @@ import {
   type ElectronAPI,
   type MultiDocumentProjectAPI,
   type OsEventsAPI,
+  type PersonalizationAPI,
   type SingleDocumentProjectAPI,
 } from '../../renderer';
 import {
@@ -29,6 +30,7 @@ import type {
   RunWasiCLIArgs,
   Wasm as WasmAPI,
 } from '../modules/infrastructure/wasm';
+import { type ResolvedTheme } from '../modules/personalization/theme';
 import { registerIpcListener } from './utils';
 
 contextBridge.exposeInMainWorld('electronAPI', {
@@ -47,6 +49,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   downloadUpdate: () => ipcRenderer.invoke('download-update'),
   restartToInstallUpdate: () => ipcRenderer.invoke('restart-to-install-update'),
 } as ElectronAPI);
+
+contextBridge.exposeInMainWorld('personalizationAPI', {
+  setTheme: (theme) => ipcRenderer.send('set-theme', theme),
+  getTheme: () => ipcRenderer.invoke('get-theme'),
+  getSystemTheme: () => ipcRenderer.invoke('get-system-theme'),
+  onSystemThemeUpdate: (callback) =>
+    registerIpcListener<ResolvedTheme>('system-theme-update', callback),
+} as PersonalizationAPI);
 
 contextBridge.exposeInMainWorld('automergeRepoNetworkAdapter', {
   sendRendererProcessMessage: (

--- a/src/renderer/src/AppWrapper.tsx
+++ b/src/renderer/src/AppWrapper.tsx
@@ -1,7 +1,9 @@
 import { RepresentationTransformProvider } from '../../modules/domain/rich-text/react/representation-transform-context';
 import { WasmProvider } from '../../modules/infrastructure/wasm/react/wasm-context';
-import { FunctionalityConfigProvider } from '../../modules/personalization/functionality-config';
-import { ThemeProvider } from '../../modules/personalization/theme';
+import {
+  FunctionalityConfigProvider,
+  ThemeProvider,
+} from '../../modules/personalization/browser';
 import App from './App.tsx';
 import { InfrastructureAdaptersProvider } from './app-state';
 

--- a/src/renderer/src/app-state/current-document/context.tsx
+++ b/src/renderer/src/app-state/current-document/context.tsx
@@ -38,7 +38,7 @@ import {
   type VersionedArtifactHandleChangePayload,
 } from '../../../../modules/infrastructure/version-control';
 import { isValidVersionControlId } from '../../../../modules/infrastructure/version-control';
-import { FunctionalityConfigContext } from '../../../../modules/personalization/functionality-config';
+import { FunctionalityConfigContext } from '../../../../modules/personalization/browser';
 import {
   CurrentProjectContext,
   InfrastructureAdaptersContext,

--- a/src/renderer/src/components/layout/Layout.tsx
+++ b/src/renderer/src/components/layout/Layout.tsx
@@ -1,29 +1,15 @@
-import clsx from 'clsx';
-import { type ReactNode, useContext } from 'react';
+import { type ReactNode } from 'react';
 
-import {
-  ThemeContext,
-  themes,
-} from '../../../../modules/personalization/theme';
 import { NavBar } from '../navigation/NavBar';
 import { Notifications } from '../notifications/Notifications';
 
-export const Layout = ({ children }: { children: ReactNode }) => {
-  const { theme } = useContext(ThemeContext);
-
-  const themeStyles =
-    theme === themes.dark
-      ? 'bg-neutral-800 text-white'
-      : 'bg-[#fafafa] text-black';
-
-  return (
-    <div className={clsx('flex h-full', themeStyles)}>
-      <NavBar />
-      {children}
-      <Notifications />
-      {/* container for popovers, useful for not being constrained by component 
+export const Layout = ({ children }: { children: ReactNode }) => (
+  <div className="flex h-full bg-[#fafafa] text-black dark:bg-neutral-800 dark:text-white">
+    <NavBar />
+    {children}
+    <Notifications />
+    {/* container for popovers, useful for not being constrained by component 
       hierarchy in the z axis. Meant to be used with React's `createPortal` */}
-      <div id="popover-container" />
-    </div>
-  );
-};
+    <div id="popover-container" />
+  </div>
+);

--- a/src/renderer/src/pages/document/main/history/DocumentHistoricalView.tsx
+++ b/src/renderer/src/pages/document/main/history/DocumentHistoricalView.tsx
@@ -15,7 +15,7 @@ import {
   isValidVersionControlId,
   UrlHeads,
 } from '../../../../../../modules/infrastructure/version-control';
-import { FunctionalityConfigContext } from '../../../../../../modules/personalization/functionality-config';
+import { FunctionalityConfigContext } from '../../../../../../modules/personalization/browser';
 import {
   CurrentDocumentContext,
   SidebarLayoutContext,

--- a/src/renderer/src/pages/document/sidebar/document-history/ChangeLog.tsx
+++ b/src/renderer/src/pages/document/sidebar/document-history/ChangeLog.tsx
@@ -12,7 +12,7 @@ import {
 import {
   ThemeContext,
   themes,
-} from '../../../../../../modules/personalization/theme';
+} from '../../../../../../modules/personalization/browser';
 import { TimelinePoint } from '../../../../components/icons/TimelinePoint';
 
 const Commit = ({
@@ -28,7 +28,7 @@ const Commit = ({
   isFirst?: boolean;
   isLast?: boolean;
 }) => {
-  const { theme } = useContext(ThemeContext);
+  const { resolvedTheme } = useContext(ThemeContext);
   const themeStyles = isSelected ? 'font-bold' : '';
   return (
     <div
@@ -39,7 +39,7 @@ const Commit = ({
         <div className="h-full w-14 flex-shrink-0">
           <TimelinePoint
             circleSize={7.5}
-            color={theme === themes.light ? '#9352FF' : '#C8B1FF'}
+            color={resolvedTheme === themes.light ? '#9352FF' : '#C8B1FF'}
             hasTopStem={!isFirst}
             hasBottomStem={!isLast}
           />
@@ -64,7 +64,7 @@ const UncommittedChange = ({
   isFirst?: boolean;
   isLast?: boolean;
 }) => {
-  const { theme } = useContext(ThemeContext);
+  const { resolvedTheme } = useContext(ThemeContext);
 
   return (
     <div
@@ -75,7 +75,7 @@ const UncommittedChange = ({
       <div className="flex flex-row items-center">
         <div className="h-full w-14 flex-shrink-0">
           <TimelinePoint
-            color={theme === themes.light ? '#2C2C2C' : '#fff'}
+            color={resolvedTheme === themes.light ? '#2C2C2C' : '#fff'}
             circleSize={12.5}
             circleStrokeSize={5}
             circleFillColor="transparent"

--- a/src/renderer/src/pages/options/SectionHeader.tsx
+++ b/src/renderer/src/pages/options/SectionHeader.tsx
@@ -11,6 +11,6 @@ export const SectionHeader = ({ icon: Icon, heading }: SectionHeaderProps) => (
     {Icon && (
       <Icon className="text-black text-opacity-90 dark:text-white dark:text-opacity-90" />
     )}
-    <Heading2>{heading}</Heading2>
+    <Heading2 className="mb-0">{heading}</Heading2>
   </div>
 );

--- a/src/renderer/src/pages/options/ThemeSection.tsx
+++ b/src/renderer/src/pages/options/ThemeSection.tsx
@@ -3,21 +3,26 @@ import { useContext } from 'react';
 import {
   ThemeContext,
   themes,
-} from '../../../../modules/personalization/theme';
+} from '../../../../modules/personalization/browser';
 import { MoonIcon, SunIcon } from '../../components/icons';
 import { Label } from '../../components/inputs/Fieldset';
 import { Radio, RadioField, RadioGroup } from '../../components/inputs/Radio';
 import { SectionHeader } from './SectionHeader';
 
 export const ThemeSection = () => {
-  const { theme, setTheme } = useContext(ThemeContext);
+  const { theme, resolvedTheme, setTheme } = useContext(ThemeContext);
+
   return (
     <div>
       <SectionHeader
-        icon={theme === themes.dark ? MoonIcon : SunIcon}
+        icon={resolvedTheme === themes.dark ? MoonIcon : SunIcon}
         heading="Theme"
       />
       <RadioGroup name="theme" value={theme} onChange={setTheme}>
+        <RadioField>
+          <Radio value={themes.system} color="purple" />
+          <Label>System</Label>
+        </RadioField>
         <RadioField>
           <Radio value={themes.light} color="purple" />
           <Label>Light</Label>


### PR DESCRIPTION
## Description

With this PR, the app updates the macOS title bar based on the selected theme.

Also, a "system" theme option is added so that the app respects the OS theme if the user selects so.

## Related Issue

Closes #212 

## Screenshots (_if applicable_)

https://github.com/user-attachments/assets/69cc8b9e-cebd-4c9c-a4d8-1001f708407e

## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
