### PR TITLE
feat: style scrollbars in dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,6 +229,7 @@
     "storybook-addon-remix-react-router": "^4.0.1",
     "storybook-dark-mode": "^4.0.2",
     "tailwindcss": "^3.4.17",
+    "tailwind-scrollbar": "^3.1.0",
     "ts-jest": "^29.3.4",
     "type-fest": "^4.41.0",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       storybook-dark-mode:
         specifier: ^4.0.2
         version: 4.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.5.3))
+      tailwind-scrollbar:
+        specifier: ^3.1.0
+        version: 3.1.0(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@22.15.21)(typescript@5.8.3)))
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@22.15.21)(typescript@5.8.3))
@@ -4534,6 +4537,12 @@ packages:
 
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
+
+  tailwind-scrollbar@3.1.0:
+    resolution: {integrity: sha512-pmrtDIZeHyu2idTejfV59SbaJyvp1VRjYxAjZBH0jnyrPRo6HL1kD5Glz8VPagasqr6oAx6M05+Tuw429Z8jxg==}
+    engines: {node: '>=12.13.0'}
+    peerDependencies:
+      tailwindcss: 3.x
 
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
@@ -9892,6 +9901,10 @@ snapshots:
       '@pkgr/core': 0.2.4
 
   tabbable@6.2.0: {}
+
+  tailwind-scrollbar@3.1.0(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@22.15.21)(typescript@5.8.3))):
+    dependencies:
+      tailwindcss: 3.4.17(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@22.15.21)(typescript@5.8.3))
 
   tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@22.15.21)(typescript@5.8.3)):
     dependencies:

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -2,6 +2,17 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  .overflow-auto,
+  .overflow-scroll,
+  .overflow-x-auto,
+  .overflow-y-auto,
+  .overflow-x-scroll,
+  .overflow-y-scroll {
+    @apply scrollbar scrollbar-track-transparent scrollbar-thumb-neutral-300 dark:scrollbar-thumb-neutral-600;
+  }
+}
+
 #root {
   margin: 0 auto;
   text-align: center;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,3 +1,4 @@
+import tailwindScrollbar from 'tailwind-scrollbar';
 import type { Config } from 'tailwindcss';
 
 export default {
@@ -39,6 +40,6 @@ export default {
       sans: ['Montserrat', 'sans-serif'],
     },
   },
-  plugins: [],
+  plugins: [tailwindScrollbar],
   darkMode: 'selector',
 } as Config;


### PR DESCRIPTION
## Description

This PR introduces custom scrollbars using a Tailwind plugin to fix how they are styled in the dark theme.

It still needs to be figured out how to change the scrollbar color on hover/active styles (a new issue will be created for this).

## Related Issue

Closes #214 

## Screenshots (_if applicable_)

<img width="2560" height="1402" alt="Screenshot 2025-09-25 at 4 14 33 PM" src="https://github.com/user-attachments/assets/0266d3e0-b7a2-4325-bc73-48763bf4dd0c" />


## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
