### PR TITLE
feat: add command palette menu item

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "compile": "tsc",
     "dev": "electron-vite dev -w --outDir=dist",
     "debug": "electron-vite dev -w --outDir=dist -- --inspect=9229",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 25",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 50",
     "postinstall": "electron-builder install-app-deps",
     "prebuild": "pnpm run compile",
     "start": "electron-vite preview --outDir=dist",

--- a/renderer.d.ts
+++ b/renderer.d.ts
@@ -39,6 +39,7 @@ export type ElectronAPI = {
   ) => () => void;
   downloadUpdate: () => Promise<void>;
   restartToInstallUpdate: () => Promise<void>;
+  onOpenCommandPalette: (callback: () => void) => () => void;
 };
 
 export type PersonalizationAPI = {

--- a/renderer.d.ts
+++ b/renderer.d.ts
@@ -39,7 +39,7 @@ export type ElectronAPI = {
   ) => () => void;
   downloadUpdate: () => Promise<void>;
   restartToInstallUpdate: () => Promise<void>;
-  onOpenCommandPalette: (callback: () => void) => () => void;
+  onToggleCommandPalette: (callback: () => void) => () => void;
 };
 
 export type PersonalizationAPI = {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -38,7 +38,7 @@ export const buildMenu = () => {
     {
       label: 'Command Palette',
       accelerator: isMac ? 'Cmd+K' : 'Ctrl+K',
-      click: () => sendIPCMessageToFocusedWindow('open-command-palette'),
+      click: () => sendIPCMessageToFocusedWindow('toggle-command-palette'),
     },
     { type: 'separator' },
     { role: 'reload' },

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -34,9 +34,21 @@ export const buildMenu = () => {
     { role: 'quit' },
   ];
 
+  const viewMenuSubmenu: MenuItemConstructorOptions[] = [
+    { role: 'reload' },
+    { role: 'forceReload' },
+    { role: 'toggleDevTools' },
+    { type: 'separator' },
+    { role: 'resetZoom' },
+    { role: 'zoomIn' },
+    { role: 'zoomOut' },
+    { type: 'separator' },
+    { role: 'togglefullscreen' },
+  ];
+
   const editMenuSubmenu: MenuItemConstructorOptions[] = [
     {
-      label: 'Command Palette…',
+      label: 'Command Palette',
       accelerator: isMac ? 'Cmd+K' : 'Ctrl+K',
       click: () => sendIPCMessageToFocusedWindow('open-command-palette'),
     },
@@ -75,11 +87,11 @@ export const buildMenu = () => {
         ]
       : []),
     { role: 'fileMenu' },
+    { role: 'editMenu' },
     {
-      label: 'Edit',
+      label: 'View',
       submenu: editMenuSubmenu,
     },
-    { role: 'viewMenu' },
     { role: 'windowMenu' },
     {
       role: 'help',

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -35,6 +35,12 @@ export const buildMenu = () => {
   ];
 
   const viewMenuSubmenu: MenuItemConstructorOptions[] = [
+    {
+      label: 'Command Palette',
+      accelerator: isMac ? 'Cmd+K' : 'Ctrl+K',
+      click: () => sendIPCMessageToFocusedWindow('open-command-palette'),
+    },
+    { type: 'separator' },
     { role: 'reload' },
     { role: 'forceReload' },
     { role: 'toggleDevTools' },
@@ -44,37 +50,6 @@ export const buildMenu = () => {
     { role: 'zoomOut' },
     { type: 'separator' },
     { role: 'togglefullscreen' },
-  ];
-
-  const editMenuSubmenu: MenuItemConstructorOptions[] = [
-    {
-      label: 'Command Palette',
-      accelerator: isMac ? 'Cmd+K' : 'Ctrl+K',
-      click: () => sendIPCMessageToFocusedWindow('open-command-palette'),
-    },
-    { type: 'separator' },
-    { role: 'undo' },
-    { role: 'redo' },
-    { type: 'separator' },
-    { role: 'cut' },
-    { role: 'copy' },
-    { role: 'paste' },
-    ...(isMac
-      ? ([
-          { role: 'pasteAndMatchStyle' },
-          { role: 'delete' },
-          { role: 'selectAll' },
-          { type: 'separator' },
-          {
-            label: 'Speech',
-            submenu: [{ role: 'startSpeaking' }, { role: 'stopSpeaking' }],
-          },
-        ] as MenuItemConstructorOptions[])
-      : ([
-          { role: 'delete' },
-          { type: 'separator' },
-          { role: 'selectAll' },
-        ] as MenuItemConstructorOptions[])),
   ];
 
   const template: MenuItemConstructorOptions[] = [
@@ -90,7 +65,7 @@ export const buildMenu = () => {
     { role: 'editMenu' },
     {
       label: 'View',
-      submenu: editMenuSubmenu,
+      submenu: viewMenuSubmenu,
     },
     { role: 'windowMenu' },
     {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,6 +1,19 @@
-import { app, Menu, type MenuItemConstructorOptions, shell } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  Menu,
+  type MenuItemConstructorOptions,
+  shell,
+} from 'electron';
 
 import { checkForUpdates } from './update';
+
+const sendIPCMessageToFocusedWindow = (message: string) => {
+  const focused = BrowserWindow.getFocusedWindow();
+  if (focused && !focused.isDestroyed()) {
+    focused.webContents.send(message);
+  }
+};
 
 export const buildMenu = () => {
   const isMac = process.platform === 'darwin';
@@ -21,6 +34,37 @@ export const buildMenu = () => {
     { role: 'quit' },
   ];
 
+  const editMenuSubmenu: MenuItemConstructorOptions[] = [
+    {
+      label: 'Command Palette…',
+      accelerator: isMac ? 'Cmd+K' : 'Ctrl+K',
+      click: () => sendIPCMessageToFocusedWindow('open-command-palette'),
+    },
+    { type: 'separator' },
+    { role: 'undo' },
+    { role: 'redo' },
+    { type: 'separator' },
+    { role: 'cut' },
+    { role: 'copy' },
+    { role: 'paste' },
+    ...(isMac
+      ? ([
+          { role: 'pasteAndMatchStyle' },
+          { role: 'delete' },
+          { role: 'selectAll' },
+          { type: 'separator' },
+          {
+            label: 'Speech',
+            submenu: [{ role: 'startSpeaking' }, { role: 'stopSpeaking' }],
+          },
+        ] as MenuItemConstructorOptions[])
+      : ([
+          { role: 'delete' },
+          { type: 'separator' },
+          { role: 'selectAll' },
+        ] as MenuItemConstructorOptions[])),
+  ];
+
   const template: MenuItemConstructorOptions[] = [
     ...(isMac
       ? [
@@ -31,7 +75,10 @@ export const buildMenu = () => {
         ]
       : []),
     { role: 'fileMenu' },
-    { role: 'editMenu' },
+    {
+      label: 'Edit',
+      submenu: editMenuSubmenu,
+    },
     { role: 'viewMenu' },
     { role: 'windowMenu' },
     {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -48,6 +48,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     registerIpcListener<UpdateState>('update-state', callback),
   downloadUpdate: () => ipcRenderer.invoke('download-update'),
   restartToInstallUpdate: () => ipcRenderer.invoke('restart-to-install-update'),
+  onOpenCommandPalette: (callback) =>
+    registerIpcListener<void>('open-command-palette', callback),
 } as ElectronAPI);
 
 contextBridge.exposeInMainWorld('personalizationAPI', {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -48,8 +48,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     registerIpcListener<UpdateState>('update-state', callback),
   downloadUpdate: () => ipcRenderer.invoke('download-update'),
   restartToInstallUpdate: () => ipcRenderer.invoke('restart-to-install-update'),
-  onOpenCommandPalette: (callback) =>
-    registerIpcListener<void>('open-command-palette', callback),
+  onToggleCommandPalette: (callback) =>
+    registerIpcListener<void>('toggle-command-palette', callback),
 } as ElectronAPI);
 
 contextBridge.exposeInMainWorld('personalizationAPI', {

--- a/src/renderer/src/AppWrapper.tsx
+++ b/src/renderer/src/AppWrapper.tsx
@@ -5,7 +5,10 @@ import {
   ThemeProvider,
 } from '../../modules/personalization/browser';
 import App from './App.tsx';
-import { InfrastructureAdaptersProvider } from './app-state';
+import {
+  CommandPaletteStateProvider,
+  InfrastructureAdaptersProvider,
+} from './app-state';
 
 export const AppWrapper = () => {
   return (
@@ -14,7 +17,9 @@ export const AppWrapper = () => {
         <RepresentationTransformProvider>
           <ThemeProvider>
             <FunctionalityConfigProvider>
-              <App />
+              <CommandPaletteStateProvider>
+                <App />
+              </CommandPaletteStateProvider>
             </FunctionalityConfigProvider>
           </ThemeProvider>
         </RepresentationTransformProvider>

--- a/src/renderer/src/app-state/command-palette/context.tsx
+++ b/src/renderer/src/app-state/command-palette/context.tsx
@@ -1,0 +1,58 @@
+import { createContext, useEffect, useState } from 'react';
+
+import { useKeyBindings } from '../../hooks';
+
+export type CommandPaletteContextType = {
+  isOpen: boolean;
+  openCommandPalette: () => void;
+  closeCommandPalette: () => void;
+};
+
+export const CommandPaletteContext = createContext<CommandPaletteContextType>({
+  isOpen: false,
+  openCommandPalette: () => {},
+  closeCommandPalette: () => {},
+});
+
+export const CommandPaletteStateProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    const unsubscribeFromCommandPaletteOpenEvent =
+      window.electronAPI?.onOpenCommandPalette(() => {
+        setIsOpen((state) => !state);
+      });
+
+    return () => {
+      unsubscribeFromCommandPaletteOpenEvent?.();
+    };
+  }, []);
+
+  useKeyBindings({
+    'ctrl+k': () => setIsOpen((state) => !state),
+  });
+
+  const handleOpenCommandPalette = () => {
+    setIsOpen(true);
+  };
+
+  const handleCloseCommandPalette = () => {
+    setIsOpen(true);
+  };
+
+  return (
+    <CommandPaletteContext.Provider
+      value={{
+        isOpen,
+        openCommandPalette: handleOpenCommandPalette,
+        closeCommandPalette: handleCloseCommandPalette,
+      }}
+    >
+      {children}
+    </CommandPaletteContext.Provider>
+  );
+};

--- a/src/renderer/src/app-state/command-palette/context.tsx
+++ b/src/renderer/src/app-state/command-palette/context.tsx
@@ -23,7 +23,7 @@ export const CommandPaletteStateProvider = ({
 
   useEffect(() => {
     const unsubscribeFromCommandPaletteOpenEvent =
-      window.electronAPI?.onOpenCommandPalette(() => {
+      window.electronAPI?.onToggleCommandPalette(() => {
         setIsOpen((state) => !state);
       });
 

--- a/src/renderer/src/app-state/command-palette/context.tsx
+++ b/src/renderer/src/app-state/command-palette/context.tsx
@@ -41,7 +41,7 @@ export const CommandPaletteStateProvider = ({
   };
 
   const handleCloseCommandPalette = () => {
-    setIsOpen(true);
+    setIsOpen(false);
   };
 
   return (

--- a/src/renderer/src/app-state/index.ts
+++ b/src/renderer/src/app-state/index.ts
@@ -24,6 +24,12 @@ export {
 } from './current-project/single-document-project-context';
 
 export {
+  CommandPaletteContext,
+  type CommandPaletteContextType,
+  CommandPaletteStateProvider,
+} from './command-palette/context';
+
+export {
   SidebarLayoutContext,
   type SidebarLayoutContextType,
   SidebarLayoutProvider,

--- a/src/renderer/src/components/dialogs/command-palette/CommandPalette.tsx
+++ b/src/renderer/src/components/dialogs/command-palette/CommandPalette.tsx
@@ -47,7 +47,7 @@ export type ActionOption = {
 export type CommandPaletteProps = {
   open?: boolean;
   onClose: () => void;
-  documentsGroupTitle: string;
+  documentsGroupTitle?: string;
   contextualSection?: {
     groupTitle: string;
     actions: Array<ActionOption>;

--- a/src/renderer/src/components/dialogs/command-palette/GenericCommandPalette.tsx
+++ b/src/renderer/src/components/dialogs/command-palette/GenericCommandPalette.tsx
@@ -1,0 +1,43 @@
+import { useContext } from 'react';
+
+import { ElectronContext } from '../../../../../modules/infrastructure/cross-platform';
+import { CommandPaletteContext } from '../../../app-state';
+import { useClearWebStorage } from '../../../hooks';
+import { useDocumentSelection as useDocumentSelectionInSingleDocumentProject } from '../../../hooks/single-document-project';
+import { type ActionOption, CommandPalette } from './CommandPalette';
+
+export const GenericCommandPalette = () => {
+  const { isOpen: isCommandPaletteOpen, closeCommandPalette } = useContext(
+    CommandPaletteContext
+  );
+
+  const { isElectron, checkForUpdate } = useContext(ElectronContext);
+
+  useDocumentSelectionInSingleDocumentProject();
+  const clearWebStorage = useClearWebStorage();
+
+  const electronSpecificActions: ActionOption[] = [
+    {
+      name: 'Check for updates',
+      onActionSelection: checkForUpdate,
+    },
+    {
+      name: 'Clear application data',
+      onActionSelection: clearWebStorage,
+    },
+  ];
+
+  const browserSpecificActions: ActionOption[] = [];
+
+  const generalActions = [
+    ...(isElectron ? electronSpecificActions : browserSpecificActions),
+  ];
+
+  return (
+    <CommandPalette
+      open={isCommandPaletteOpen}
+      onClose={closeCommandPalette}
+      actions={generalActions}
+    />
+  );
+};

--- a/src/renderer/src/pages/document/command-palette/index.tsx
+++ b/src/renderer/src/pages/document/command-palette/index.tsx
@@ -1,10 +1,11 @@
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 
 import { projectTypes } from '../../../../../modules/domain/project';
 import { richTextRepresentations } from '../../../../../modules/domain/rich-text';
 import { ElectronContext } from '../../../../../modules/infrastructure/cross-platform';
 import { removeExtension } from '../../../../../modules/infrastructure/filesystem';
 import {
+  CommandPaletteContext,
   CurrentDocumentContext,
   CurrentProjectContext,
 } from '../../../app-state';
@@ -17,7 +18,6 @@ import {
   useCurrentDocumentName,
   useDocumentList,
   useExport,
-  useKeyBindings,
 } from '../../../hooks';
 import { useDocumentSelection as useDocumentSelectionInMultiDocumentProject } from '../../../hooks/multi-document-project';
 import { useDocumentSelection as useDocumentSelectionInSingleDocumentProject } from '../../../hooks/single-document-project';
@@ -29,18 +29,12 @@ export const DocumentCommandPalette = ({
   onCreateDocument: () => void;
   onOpenDocument: () => void;
 }) => {
-  const [isCommandPaletteOpen, setCommandPaletteOpen] =
-    useState<boolean>(false);
+  const { isOpen: isCommandPaletteOpen, closeCommandPalette } = useContext(
+    CommandPaletteContext
+  );
   const { projectType } = useContext(CurrentProjectContext);
   const { canCommit, onOpenCommitDialog } = useContext(CurrentDocumentContext);
   const { isElectron, checkForUpdate } = useContext(ElectronContext);
-
-  // here we register the key bindings that are not
-  // already covered by the command palette
-  // as the command palette is registering any actions having shortcuts
-  useKeyBindings({
-    'ctrl+k': () => setCommandPaletteOpen((state) => !state),
-  });
 
   const handleDocumentSelectionInMultiDocumentProject =
     useDocumentSelectionInMultiDocumentProject();
@@ -91,7 +85,7 @@ export const DocumentCommandPalette = ({
   return (
     <CommandPalette
       open={isCommandPaletteOpen}
-      onClose={() => setCommandPaletteOpen(false)}
+      onClose={closeCommandPalette}
       documentsGroupTitle={`${projectType === projectTypes.SINGLE_DOCUMENT_PROJECT ? 'Other' : 'Project'}  documents`}
       contextualSection={
         currentDocumentName
@@ -144,7 +138,7 @@ export const DocumentCommandPalette = ({
           title: removeExtension(doc.name),
           onDocumentSelection: () => {
             handleDocumentSelection(doc.id);
-            setCommandPaletteOpen(false);
+            closeCommandPalette();
           },
         }))}
       actions={generalActions}

--- a/src/renderer/src/pages/options/Options.tsx
+++ b/src/renderer/src/pages/options/Options.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { GenericCommandPalette } from '../../components/dialogs/command-palette/GenericCommandPalette';
 import { Layout } from '../../components/layout/Layout';
 import { ThemeSection } from './ThemeSection';
 
@@ -13,6 +14,7 @@ export const Options = () => {
       <div className="container mx-auto my-6 max-w-2xl">
         <ThemeSection />
       </div>
+      <GenericCommandPalette />
     </Layout>
   );
 };


### PR DESCRIPTION
## Description

Add a command palette menu item to make the command palette more easily discoverable.

**Note**: With this, we have to handle opening the command palette in a screen where it wasn't available before (e.g. Options). For this reason, a generic command palette component was created and used there.

## Related Issue

Closes #220 

## Screenshots (_if applicable_)

https://github.com/user-attachments/assets/3a24081d-f9c6-4608-9552-4092f4f5fbc8

## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
