### PR TITLE
fix: fetch document before exporting

### DIFF
--- a/src/renderer/src/app-state/current-document/context.tsx
+++ b/src/renderer/src/app-state/current-document/context.tsx
@@ -603,7 +603,7 @@ export const CurrentDocumentProvider = ({
 
       // We fetch the latest version of the document to ensure we have the most up-to-date content
       const { artifact: document } = await Effect.runPromise(
-        versionedDocumentStore.findDocumentById(documentId!)
+        versionedDocumentStore.findDocumentById(documentId)
       );
 
       const documentContent = getDocumentRichTextContent(document);


### PR DESCRIPTION
## Description

Always fetch the current state of the document before exporting.

## Related Issue

Closes #226 

## Checklist

- [X] I have performed a self-review of my own code
- [X] My code follows the project's coding standards
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
