### PR TITLE
Add an empty directory view (multi-doc projects)

### DIFF
--- a/src/renderer/src/pages/project/shared/document-list-views/DocumentList.tsx
+++ b/src/renderer/src/pages/project/shared/document-list-views/DocumentList.tsx
@@ -14,27 +14,25 @@ export const DocumentList = ({
 }: {
   items: Array<DocumentListItem>;
   onSelectItem: (id: string) => Promise<void>;
-}) => {
-  return (
-    <ul className="flex flex-col items-stretch text-black dark:text-white">
-      {items.map((item) => (
-        <li
-          key={item.name}
-          className={clsx(
-            'py-1 pl-9 pr-4 hover:bg-zinc-950/5 dark:hover:bg-white/5',
-            item.isSelected ? 'bg-purple-50 dark:bg-neutral-600' : ''
-          )}
+}) => (
+  <ul className="flex flex-col items-stretch text-black dark:text-white">
+    {items.map((item) => (
+      <li
+        key={item.name}
+        className={clsx(
+          'py-1 pl-9 pr-4 hover:bg-zinc-950/5 dark:hover:bg-white/5',
+          item.isSelected ? 'bg-purple-50 dark:bg-neutral-600' : ''
+        )}
+      >
+        <button
+          className="flex w-full items-center truncate bg-transparent text-left"
+          title={item.name}
+          onClick={async () => onSelectItem(item.id)}
         >
-          <button
-            className="flex w-full items-center truncate bg-transparent text-left"
-            title={item.name}
-            onClick={async () => onSelectItem(item.id)}
-          >
-            <FileDocumentIcon className="mr-1" size={16} />
-            {item.name}
-          </button>
-        </li>
-      ))}
-    </ul>
-  );
-};
+          <FileDocumentIcon className="mr-1" size={16} />
+          {item.name}
+        </button>
+      </li>
+    ))}
+  </ul>
+);

--- a/src/renderer/src/pages/project/shared/document-list-views/directory-files/EmptyView.tsx
+++ b/src/renderer/src/pages/project/shared/document-list-views/directory-files/EmptyView.tsx
@@ -1,0 +1,23 @@
+import { Button } from '../../../../../components/actions/Button';
+import { PenIcon } from '../../../../../components/icons';
+
+export const EmptyView = ({
+  onCreateDocumentButtonClick,
+}: {
+  onCreateDocumentButtonClick: () => void;
+}) => {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4">
+      <p>The directory has no documents.</p>
+      <Button
+        onClick={onCreateDocumentButtonClick}
+        variant="solid"
+        color="purple"
+        className="w-64"
+      >
+        <PenIcon className="mr-1" />
+        Create document
+      </Button>
+    </div>
+  );
+};

--- a/src/renderer/src/pages/project/shared/document-list-views/directory-files/index.tsx
+++ b/src/renderer/src/pages/project/shared/document-list-views/directory-files/index.tsx
@@ -1,13 +1,44 @@
 import { useContext } from 'react';
 
+import { type Directory } from '../../../../../../../modules/infrastructure/filesystem';
 import { MultiDocumentProjectContext } from '../../../../../app-state';
 import { IconButton } from '../../../../../components/actions/IconButton';
 import { FolderIcon, PlusIcon } from '../../../../../components/icons';
 import { SidebarHeading } from '../../../../../components/sidebar/SidebarHeading';
-import { useCreateDocument, useDocumentList } from '../../../../../hooks';
+import {
+  type DocumentListItem,
+  useCreateDocument,
+  useDocumentList,
+} from '../../../../../hooks';
 import { useDocumentSelection as useDocumentSelectionInMultiDocumentProject } from '../../../../../hooks/multi-document-project';
 import { DocumentList } from '../DocumentList';
+import { EmptyView } from './EmptyView';
 import { NoActiveDirectoryView } from './NoActiveDirectoryView';
+
+const DirectoryFilesList = ({
+  directory,
+  documents,
+  onCreateDocument,
+  onSelectItem,
+}: {
+  directory: Directory | null;
+  documents: DocumentListItem[];
+  onCreateDocument: () => void;
+  onSelectItem: (id: string) => Promise<void>;
+}) => {
+  if (documents.length > 0) {
+    return (
+      <div className="flex flex-col items-stretch overflow-auto">
+        <div className="mb-1 truncate px-4 text-left font-bold text-black text-opacity-85 dark:text-white dark:text-opacity-85">
+          {directory?.name ?? 'Files'}
+        </div>
+        <DocumentList items={documents} onSelectItem={onSelectItem} />
+      </div>
+    );
+  }
+
+  return <EmptyView onCreateDocumentButtonClick={onCreateDocument} />;
+};
 
 export const DirectoryFiles = ({
   onCreateDocument,
@@ -36,15 +67,12 @@ export const DirectoryFiles = ({
       </div>
 
       {canShowList ? (
-        <div className="flex flex-col items-stretch overflow-auto">
-          <div className="mb-1 truncate px-4 text-left font-bold text-black text-opacity-85 dark:text-white dark:text-opacity-85">
-            {directory?.name ?? 'Files'}
-          </div>
-          <DocumentList
-            items={documents}
-            onSelectItem={handleDocumentSelection}
-          />
-        </div>
+        <DirectoryFilesList
+          directory={directory}
+          documents={documents}
+          onCreateDocument={onCreateDocument}
+          onSelectItem={handleDocumentSelection}
+        />
       ) : (
         <NoActiveDirectoryView />
       )}


### PR DESCRIPTION
## Description

This PR adds a view for empty directories in multi-doc projects, prompting the user to add a document.

## Related Issue

Closes #247 

## Screenshots (_if applicable_)

<img width="723" height="1109" alt="Screenshot 2025-12-29 at 4 09 28 PM" src="https://github.com/user-attachments/assets/0bd8f726-ff42-4fd8-b015-6482b1b7a4da" />

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
