### PR TITLE
Fix PKGBUILD architecture filename from x64 to x86_64

### DIFF
--- a/scripts/aur/PKGBUILD.template
+++ b/scripts/aur/PKGBUILD.template
@@ -12,17 +12,13 @@ optdepends=('libappindicator-gtk3: tray icon support')
 provides=('v2')
 conflicts=('v2')
 options=('!strip' '!debug')
-source_x86_64=("https://github.com/oktana-coop/v2/releases/download/v${pkgver}/v2-${pkgver}-x64.AppImage")
-source_aarch64=("https://github.com/oktana-coop/v2/releases/download/v${pkgver}/v2-${pkgver}-arm64.AppImage")
+source_x86_64=("v2-${pkgver}.AppImage::https://github.com/oktana-coop/v2/releases/download/v${pkgver}/v2-${pkgver}-x86_64.AppImage")
+source_aarch64=("v2-${pkgver}.AppImage::https://github.com/oktana-coop/v2/releases/download/v${pkgver}/v2-${pkgver}-arm64.AppImage")
 sha256sums_x86_64=('@@SHA256_X86_64@@')
 sha256sums_aarch64=('@@SHA256_AARCH64@@')
 
 prepare() {
-    if [[ "$CARCH" == "x86_64" ]]; then
-        _appimage="v2-${pkgver}.AppImage"
-    else
-        _appimage="v2-${pkgver}-arm64.AppImage"
-    fi
+    _appimage="v2-${pkgver}.AppImage"
     chmod +x "${srcdir}/${_appimage}"
     "${srcdir}/${_appimage}" --appimage-extract
 }


### PR DESCRIPTION
## Summary
- Fixed incorrect architecture naming in PKGBUILD template (x64 -> x86_64)
- Simplified prepare() function by using URL renaming for consistent local filenames
- Both architectures now extract to the same filename, eliminating conditional logic

## Test plan
- [ ] Verify PKGBUILD builds correctly on x86_64 systems
- [ ] Verify PKGBUILD builds correctly on aarch64 systems
- [ ] Confirm AppImage extraction works properly for both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)