### PR TITLE
Update HS lib and allow markdown frontmatter

### DIFF
--- a/src/modules/domain/rich-text/adapters/automerge-pandoc-cli/index.ts
+++ b/src/modules/domain/rich-text/adapters/automerge-pandoc-cli/index.ts
@@ -50,6 +50,7 @@ export const createAdapter = ({
         representationToCliArg(from),
         '--to',
         representationToCliArg(to),
+        '--',
         input,
       ],
     });

--- a/src/modules/domain/rich-text/adapters/pandoc-diff/index.ts
+++ b/src/modules/domain/rich-text/adapters/pandoc-diff/index.ts
@@ -106,6 +106,7 @@ export const createAdapter = ({
         'proseMirrorDiff',
         '--from',
         representationToCliArg(representation),
+        '--',
         docBefore,
         docAfter,
       ],

--- a/src/modules/domain/rich-text/prosemirror/schema.ts
+++ b/src/modules/domain/rich-text/prosemirror/schema.ts
@@ -59,6 +59,9 @@ const schemaSpec: SchemaSpec = {
     /// NodeSpec The top level document node.
     doc: {
       content: 'block+',
+      attrs: {
+        pandocMeta: { default: null },
+      },
     },
 
     /// A plain paragraph textblock. Represented in the DOM

--- a/src/modules/infrastructure/wasm/files/v2-hs-lib.wasm
+++ b/src/modules/infrastructure/wasm/files/v2-hs-lib.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2f6373615f51ac4226ff12d3dc9fa8b2e6e43af0fd4d50f1777c6a0d9684036
-size 82134863
+oid sha256:c109b7ead69d3fb391f08a65bded46c67077dfeca9c47c7bf6a17bb5411c66a5
+size 82186289


### PR DESCRIPTION
## Description

With this PR, the following changes are made to allow Markdown frontmatter (YAML metadata):
1. Update the Haskell library to the newest version.
2. Separate positional arguments with `--` when sending data to the Haskell WASM CLI.
3. Add a `pandocMeta` attribute to the ProseMirror `doc` node spec.

## Related Issue

#275 
