### PR TITLE
feat: add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://oktana.dev"
   },
   "version": "0.11.11",
-  "license": "AGPL-3.0-only",
+  "license": "AGPL-3.0-or-later",
   "type": "module",
   "main": "./dist/main/index.js",
   "packageManager": "pnpm@10.28.2",


### PR DESCRIPTION
## Description

electron-builder uses package.json for getting the license, and it would then show on apt.

## Related Issue

[Cite any related issue(s) here]

## Screenshots (_if applicable_)

[Attach screenshots if they help illustrate the changes]

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
