### PR TITLE
feat: add keyboard shortcut for inserting footnotes

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -40,6 +40,12 @@ export const buildMenu = () => {
       click: () => sendIPCMessageToFocusedWindow('toggle-command-palette'),
     },
     { type: 'separator' },
+    {
+      label: 'Insert Footnote',
+      accelerator: isMac() ? 'Cmd+Option+F' : 'Ctrl+Alt+F',
+      click: () => sendIPCMessageToFocusedWindow('insert-footnote'),
+    },
+    { type: 'separator' },
     { role: 'reload' },
     { role: 'forceReload' },
     { role: 'toggleDevTools' },

--- a/src/renderer/src/components/editing/RichTextEditor.tsx
+++ b/src/renderer/src/components/editing/RichTextEditor.tsx
@@ -155,6 +155,7 @@ export const RichTextEditor = ({
       Enter: splitListItem(schema.nodes.list_item),
       'Mod-[': liftListItem(schema.nodes.list_item),
       'Mod-]': sinkListItem(schema.nodes.list_item),
+      'Mod-Alt-f': insertNote,
       // Disable tab keystrokes in the editor to prevent tabbing
       // to the next focusable element
       Tab: () => true,

--- a/src/renderer/src/hooks/use-key-bindings.ts
+++ b/src/renderer/src/hooks/use-key-bindings.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
-type Modifier = 'ctrl' | 'shift';
-type Letters = 'k' | 'o' | 't' | 's' | 'm' | 'h' | 'w' | 'd'; // for now only the ones used in the application
+type Modifier = 'ctrl' | 'shift' | 'alt';
+type Letters = 'k' | 'o' | 't' | 's' | 'm' | 'h' | 'w' | 'd' | 'f'; // for now only the ones used in the application
 type SpecialKey = 'enter' | 'escape' | 'tab';
 type Key = Letters | SpecialKey;
 
@@ -25,6 +25,9 @@ export const useKeyBindings = (keyBindings: KeyBindings) => {
     const metaShiftKeyBindings = Object.keys(keyBindings).filter((key) => {
       return key.startsWith('ctrl+shift+');
     });
+    const metaAltKeyBindings = Object.keys(keyBindings).filter((key) => {
+      return key.startsWith('ctrl+alt+');
+    });
 
     const handleGenericKeyDown = (event: KeyboardEvent) => {
       if (
@@ -39,6 +42,21 @@ export const useKeyBindings = (keyBindings: KeyBindings) => {
         event.preventDefault();
         const fn =
           keyBindings[`ctrl+shift+${event.key.toLowerCase()}` as KeyBinding];
+        if (fn) return fn();
+      }
+
+      if (
+        metaAltKeyBindings
+          .map((binding) => {
+            return binding.split('ctrl+alt+').slice(1)[0];
+          })
+          .includes(event.key.toLowerCase()) &&
+        (event.ctrlKey === true || event.metaKey === true) &&
+        event.altKey === true
+      ) {
+        event.preventDefault();
+        const fn =
+          keyBindings[`ctrl+alt+${event.key.toLowerCase()}` as KeyBinding];
         if (fn) return fn();
       }
 

--- a/src/renderer/src/pages/project/shared/command-palette/key-bindings.ts
+++ b/src/renderer/src/pages/project/shared/command-palette/key-bindings.ts
@@ -45,4 +45,8 @@ export const keyBindings: Record<
     command: 'Export to Docx (Microsoft Word)',
     keyBinding: 'ctrl+shift+w',
   },
+  ctrlAltF: {
+    command: 'Insert footnote',
+    keyBinding: 'ctrl+alt+f',
+  },
 } as const;


### PR DESCRIPTION
## Summary
- Adds `Ctrl+Alt+F` (Windows/Linux) / `Cmd+Option+F` (macOS) shortcut for inserting footnotes
- Extends the `useKeyBindings` hook to support `ctrl+alt+` modifier combos
- Registers the shortcut in the centralized keybinding registry, ProseMirror keymap, and Electron menu

Closes #268