### PR TITLE
feat: use ctlr+, to go to project settings

### DIFF
--- a/src/renderer/src/hooks/use-key-bindings.ts
+++ b/src/renderer/src/hooks/use-key-bindings.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 type Modifier = 'ctrl' | 'shift' | 'alt';
 type Letters = 'k' | 'o' | 't' | 's' | 'm' | 'h' | 'w' | 'd' | 'f'; // for now only the ones used in the application
-type SpecialKey = 'enter' | 'escape' | 'tab';
+type SpecialKey = 'enter' | 'escape' | 'tab' | ',';
 type Key = Letters | SpecialKey;
 
 export type KeyBinding =

--- a/src/renderer/src/pages/project/current-project/index.tsx
+++ b/src/renderer/src/pages/project/current-project/index.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect } from 'react';
-import { Outlet } from 'react-router';
+import { Outlet, useNavigate } from 'react-router';
 
+import { urlEncodeProjectId } from '../../../../../modules/domain/project';
 import {
   BranchingCommandPaletteContext,
   CreateDocumentModalContext,
@@ -49,6 +50,7 @@ const Project = () => {
     onRestoreCommit,
     onDiscardChanges,
   } = useContext(CurrentDocumentContext);
+  const navigate = useNavigate();
   const {
     isOpen: isBranchingCommandPaletteOpen,
     closeBranchingCommandPalette,
@@ -80,6 +82,13 @@ const Project = () => {
 
   const handleOpenDocument = () => openDocument();
 
+  const handleOpenProjectSettings = () => {
+    if (projectId) {
+      const projectSettingsUrL = `/projects/${urlEncodeProjectId(projectId)}/settings`;
+      navigate(projectSettingsUrL);
+    }
+  };
+
   return (
     <div className="flex h-full flex-auto flex-col">
       <div className="flex flex-auto overflow-y-auto">
@@ -107,6 +116,7 @@ const Project = () => {
         <ProjectCommandPalette
           onCreateDocument={triggerDocumentCreationDialog}
           onOpenDocument={handleOpenDocument}
+          onOpenProjectSettings={handleOpenProjectSettings}
         />
         <CreateBranchDialog
           isOpen={isCreateBranchDialogOpen}

--- a/src/renderer/src/pages/project/shared/command-palette/index.tsx
+++ b/src/renderer/src/pages/project/shared/command-palette/index.tsx
@@ -26,9 +26,11 @@ import { keyBindings } from './key-bindings';
 export const ProjectCommandPalette = ({
   onCreateDocument,
   onOpenDocument,
+  onOpenProjectSettings,
 }: {
   onCreateDocument: () => void;
   onOpenDocument: () => void;
+  onOpenProjectSettings: () => void;
 }) => {
   const { isOpen: isCommandPaletteOpen, closeCommandPalette } = useContext(
     CommandPaletteContext
@@ -79,6 +81,11 @@ export const ProjectCommandPalette = ({
       name: keyBindings.ctrlT.command,
       shortcut: keyBindings.ctrlT.keyBinding,
       onActionSelection: onCreateDocument,
+    },
+    {
+      name: keyBindings.ctrlComma.command,
+      shortcut: keyBindings.ctrlComma.keyBinding,
+      onActionSelection: onOpenProjectSettings,
     },
     ...(projectType === projectTypes.MULTI_DOCUMENT_PROJECT
       ? []

--- a/src/renderer/src/pages/project/shared/command-palette/key-bindings.ts
+++ b/src/renderer/src/pages/project/shared/command-palette/key-bindings.ts
@@ -49,4 +49,8 @@ export const keyBindings: Record<
     command: 'Insert footnote',
     keyBinding: 'ctrl+alt+f',
   },
+  ctrlComma: {
+    command: 'Open Project Settings',
+    keyBinding: 'ctrl+,',
+  },
 } as const;


### PR DESCRIPTION
## Description

This introduces a key binding to Open the Project Settings.

## Related Issue

#282

## Screenshots (_if applicable_)

<img width="1036" height="583" alt="image" src="https://github.com/user-attachments/assets/e78ed073-44e8-482e-afbc-00ad1fffbdb0" />

## Checklist

- [x] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
