### PR TITLE
fix: enable safeStorage when keyring missing

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import {
   ipcMain,
   Menu,
   nativeImage,
+  safeStorage,
   session,
   shell,
 } from 'electron';
@@ -67,6 +68,11 @@ process.env.VITE_PUBLIC = process.env.VITE_DEV_SERVER_URL
 
 // Disable GPU Acceleration for Windows 7
 if (release().startsWith('6.1')) app.disableHardwareAcceleration();
+
+// Allow safeStorage to fall back to Chromium's OSCrypt when no native keyring
+// (gnome-keyring, kwallet, macOS Keychain, Windows DPAPI) is available.
+// https://www.electronjs.org/docs/latest/api/safe-storage#safestoragesetuseplaintextencryptionuseplaintext
+safeStorage.setUsePlainTextEncryption(true);
 
 // Set application name for Windows 10+ notifications
 if (process.platform === 'win32') app.setAppUserModelId(app.getName());


### PR DESCRIPTION
## Description

I was getting this, when trying to connect to GitHub:

```sh
dev server running for the electron renderer process at:

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose

start electron app...

(node:952572) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `electron --trace-warnings ...` to show where the warning was created)
Browserslist: browsers data (caniuse-lite) is 11 months old. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
[GitHub Auth] Polling started, waiting for user approval...
[GitHub Auth] Poll response: authorization_pending
[GitHub Auth] Poll response: authorization_pending
[GitHub Auth] Poll response: authorization_pending
[GitHub Auth] Poll response: authorization_pending
[GitHub Auth] Poll response: success (token received)
[GitHub Auth] Device flow failed: (FiberFailure) Error: Encrypted storage is not available.
    at file:///home/stathis/src/v2/dist/main/index.js:12421:11
    at file:///home/stathis/src/v2/dist/main/index.js:147:92
    at file:///home/stathis/src/v2/dist/main/index.js:7690:36
Error occurred in handler for 'auth:github-device-flow': (FiberFailure) Error: Encrypted storage is not available.
    at file:///home/stathis/src/v2/dist/main/index.js:12421:11
    at file:///home/stathis/src/v2/dist/main/index.js:147:92
    at file:///home/stathis/src/v2/dist/main/index.js:7690:36
```

I do have a keyring installed, but Electron could not find it. Adding a fallback to the browser's safeStorage approach, for these cases.

## Related Issue

[Cite any related issue(s) here]

## Screenshots (_if applicable_)

[Attach screenshots if they help illustrate the changes]

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
