### PR TITLE
fix: filter out non-md files

### DIFF
--- a/src/renderer/src/pages/project/shared/command-palette/index.tsx
+++ b/src/renderer/src/pages/project/shared/command-palette/index.tsx
@@ -1,9 +1,17 @@
 import { useContext } from 'react';
 
 import { projectTypes } from '../../../../../../modules/domain/project';
-import { richTextRepresentations } from '../../../../../../modules/domain/rich-text';
+import {
+  PRIMARY_RICH_TEXT_REPRESENTATION,
+  richTextRepresentationExtensions,
+  richTextRepresentations,
+} from '../../../../../../modules/domain/rich-text';
 import { ElectronContext } from '../../../../../../modules/infrastructure/cross-platform/browser';
-import { removeExtension } from '../../../../../../modules/infrastructure/filesystem';
+import {
+  getExtension,
+  removeExtension,
+} from '../../../../../../modules/infrastructure/filesystem';
+import { filesystemItemTypes } from '../../../../../../modules/infrastructure/filesystem';
 import {
   CommandPaletteContext,
   CurrentDocumentContext,
@@ -14,6 +22,7 @@ import {
   CommandPalette,
 } from '../../../../components/dialogs/command-palette';
 import {
+  type ExplorerTreeNode,
   useClearWebStorage,
   useCurrentDocumentName,
   useDocumentExplorerTree,
@@ -22,6 +31,23 @@ import {
 import { useDocumentSelection as useDocumentSelectionInMultiDocumentProject } from '../../../../hooks/multi-document-project';
 import { useDocumentSelection as useDocumentSelectionInSingleDocumentProject } from '../../../../hooks/single-document-project';
 import { keyBindings } from './key-bindings';
+
+const openableExtension =
+  richTextRepresentationExtensions[PRIMARY_RICH_TEXT_REPRESENTATION];
+
+const collectOpenableFiles = (nodes: ExplorerTreeNode[]): ExplorerTreeNode[] =>
+  nodes.flatMap((node) => {
+    if (
+      node.type === filesystemItemTypes.FILE &&
+      getExtension(node.name) === openableExtension
+    ) {
+      return [node];
+    }
+    if (node.children) {
+      return collectOpenableFiles(node.children);
+    }
+    return [];
+  });
 
 export const ProjectCommandPalette = ({
   onCreateDocument,
@@ -158,7 +184,7 @@ export const ProjectCommandPalette = ({
             }
           : undefined
       }
-      documents={documents
+      documents={collectOpenableFiles(documents)
         .filter((doc) => doc.id !== selection)
         .map((doc) => ({
           title: removeExtension(doc.name),

--- a/src/renderer/src/pages/project/shared/explorer-tree-views/tree/TreeNode.tsx
+++ b/src/renderer/src/pages/project/shared/explorer-tree-views/tree/TreeNode.tsx
@@ -3,8 +3,15 @@ import { useContext, useEffect, useRef } from 'react';
 import { type NodeApi, type NodeRendererProps } from 'react-arborist';
 
 import { projectTypes } from '../../../../../../../modules/domain/project';
+import {
+  PRIMARY_RICH_TEXT_REPRESENTATION,
+  richTextRepresentationExtensions,
+} from '../../../../../../../modules/domain/rich-text';
 import { EXPLORER_TREE_NODE } from '../../../../../../../modules/infrastructure/cross-platform';
-import { filesystemItemTypes } from '../../../../../../../modules/infrastructure/filesystem';
+import {
+  filesystemItemTypes,
+  getExtension,
+} from '../../../../../../../modules/infrastructure/filesystem';
 import { CurrentProjectContext } from '../../../../../app-state';
 import { ChevronDownIcon, DiffIcon } from '../../../../../components/icons';
 import { FileExtensionIcon } from '../../../../../components/navigation';
@@ -258,6 +265,12 @@ const DirectoryNode = ({
   );
 };
 
+const openableExtension =
+  richTextRepresentationExtensions[PRIMARY_RICH_TEXT_REPRESENTATION];
+
+const isOpenableFile = (fileName: string) =>
+  getExtension(fileName) === openableExtension;
+
 const FileNode = ({
   node,
   style,
@@ -272,6 +285,8 @@ const FileNode = ({
   if (filePathToRename === node.data.id) {
     return <RenamingFileNode node={node} style={style} {...rest} />;
   }
+
+  const openable = isOpenableFile(node.data.name);
 
   const handleContextMenu = (ev: React.MouseEvent) => {
     ev.preventDefault();
@@ -288,12 +303,13 @@ const FileNode = ({
 
   return (
     <div
-      onClick={onClick}
+      onClick={openable ? onClick : undefined}
       onContextMenu={handleContextMenu}
-      className={nodeClasses(node)}
+      className={clsx(nodeClasses(node), !openable && 'opacity-50')}
       style={{
         ...style,
         paddingLeft: node.level * 24 + 40,
+        cursor: openable ? undefined : 'default',
       }}
     >
       <FileExtensionIcon fileName={node.data.name} />


### PR DESCRIPTION
## Description

Description:

- Non-openable files (non-md) appear greyed out and non-clickable in the file tree
- Command palette only lists openable files, now including nested ones

## Related Issue

[[Cite any related issue(s) here]](https://github.com/oktana-coop/v2/issues/323)

## Screenshots (_if applicable_)

[Attach screenshots if they help illustrate the changes]

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
