### PR TITLE
Enable committing all project changes from the doc commit dialog

### DIFF
--- a/e2e/multi-doc-project/commit-to-project.spec.ts
+++ b/e2e/multi-doc-project/commit-to-project.spec.ts
@@ -1,0 +1,107 @@
+import { Page } from '@playwright/test';
+
+import { expect, test } from '../shared/fixtures';
+import {
+  commitAllProjectChanges,
+  navigateToProjectHistory,
+  openHelloMd,
+  openProjectFolder,
+  selectUncommittedChanges,
+  toggleProjectCommit,
+  typeInEditorAndWaitForDebounce,
+} from '../shared/helpers';
+
+const openWorldMd = async ({ window }: { window: Page }): Promise<void> => {
+  await window.getByText('world').click();
+  await window.waitForSelector('.ProseMirror', { timeout: 2_000 });
+};
+
+test.describe('commit to project (multi-doc)', () => {
+  test('bundles uncommitted changes across documents into one commit', async ({
+    electronApp,
+    window,
+    testProjectDir,
+  }) => {
+    await openProjectFolder({
+      electronApp,
+      window,
+      folderPath: testProjectDir,
+    });
+
+    // Edit the first document and leave the changes uncommitted.
+    await openHelloMd({ window });
+    await typeInEditorAndWaitForDebounce({ window, text: ' hello edit' });
+
+    // Switch to the second document and edit it as well.
+    await openWorldMd({ window });
+    await typeInEditorAndWaitForDebounce({ window, text: ' world edit' });
+
+    // Trigger the project-scoped commit from the second document's editor.
+    await commitAllProjectChanges({
+      window,
+      message: 'project-scoped commit',
+    });
+
+    // The history sidebar in the document view should show the new commit.
+    const docCommits = window.getByTestId('history-commit');
+    await expect(docCommits).toHaveCount(1);
+    await expect(docCommits.first()).toContainText('project-scoped commit');
+
+    // Project history should contain a single commit with both documents.
+    await navigateToProjectHistory({ window });
+    const projectCommits = window.getByTestId('project-commit-row');
+    await expect(projectCommits).toHaveCount(1);
+    await expect(projectCommits.first()).toContainText('project-scoped commit');
+
+    await toggleProjectCommit({
+      window,
+      commitMessage: 'project-scoped commit',
+    });
+    const changedDocs = window.getByTestId('changed-document-row');
+    await expect(changedDocs.filter({ hasText: 'hello' })).toHaveCount(1);
+    await expect(changedDocs.filter({ hasText: 'world' })).toHaveCount(1);
+  });
+
+  test('works from the document history view (uncommitted changes screen)', async ({
+    electronApp,
+    window,
+    testProjectDir,
+  }) => {
+    await openProjectFolder({
+      electronApp,
+      window,
+      folderPath: testProjectDir,
+    });
+
+    // Edit both documents.
+    await openHelloMd({ window });
+    await typeInEditorAndWaitForDebounce({ window, text: ' hello edit' });
+    await openWorldMd({ window });
+    await typeInEditorAndWaitForDebounce({ window, text: ' world edit' });
+
+    // Switch from the editor to the document history view (uncommitted-changes
+    // screen) and trigger the project-scoped commit from there.
+    await selectUncommittedChanges({ window });
+    await commitAllProjectChanges({
+      window,
+      message: 'project commit from history view',
+    });
+
+    // Project history should contain a single commit with both documents,
+    // matching the outcome of the same flow fired from the editor view.
+    await navigateToProjectHistory({ window });
+    const projectCommits = window.getByTestId('project-commit-row');
+    await expect(projectCommits).toHaveCount(1);
+    await expect(projectCommits.first()).toContainText(
+      'project commit from history view'
+    );
+
+    await toggleProjectCommit({
+      window,
+      commitMessage: 'project commit from history view',
+    });
+    const changedDocs = window.getByTestId('changed-document-row');
+    await expect(changedDocs.filter({ hasText: 'hello' })).toHaveCount(1);
+    await expect(changedDocs.filter({ hasText: 'world' })).toHaveCount(1);
+  });
+});

--- a/e2e/shared/helpers.ts
+++ b/e2e/shared/helpers.ts
@@ -365,6 +365,38 @@ export const commitChanges = async ({
   await textarea.waitFor({ state: 'hidden', timeout: 5_000 });
 };
 
+/**
+ * Opens the commit dialog from the editor, fills the message, opens the
+ * SplitButton dropdown, and clicks "Commit all project changes" — the
+ * project-scoped commit option exposed for multi-document projects.
+ */
+export const commitAllProjectChanges = async ({
+  window,
+  message,
+}: {
+  window: Page;
+  message: string;
+}): Promise<void> => {
+  const commitBtn = window.getByRole('button', { name: /commit changes/i });
+  await expect(commitBtn).toBeEnabled({ timeout: 1_000 });
+  await commitBtn.click();
+
+  const textarea = window.getByRole('textbox');
+  await textarea.waitFor({ state: 'visible', timeout: 1_000 });
+  await textarea.fill(message);
+
+  // Open the SplitButton's dropdown (chevron next to the primary Commit button)
+  await window.getByRole('button', { name: /more commit options/i }).click();
+
+  // Click the "Commit all project changes" menu item
+  await window
+    .getByRole('menuitem', { name: /commit all project changes/i })
+    .click();
+
+  // Wait for the dialog to close
+  await textarea.waitFor({ state: 'hidden', timeout: 5_000 });
+};
+
 export const enableShowDiff = async ({
   window,
 }: {

--- a/src/main/ipc/versioned-stores.ts
+++ b/src/main/ipc/versioned-stores.ts
@@ -49,6 +49,7 @@ import {
   type SetupSingleDocumentProjectStoreArgs,
   type SingleDocumentProjectAbortMergeArgs,
   type SingleDocumentProjectAddRemoteProjectArgs,
+  type SingleDocumentProjectCommitChangesArgs,
   type SingleDocumentProjectCommitMergeConflictsResolutionArgs,
   type SingleDocumentProjectCreateAndSwitchToBranchArgs,
   type SingleDocumentProjectDeleteBranchArgs,
@@ -569,6 +570,26 @@ const registerSingleDocumentProjectStoreEvents = ({
           ),
           Effect.flatMap(({ versionedProjectStore }) =>
             versionedProjectStore.abortMerge(args)
+          )
+        )
+      )
+  );
+
+  ipcMain.handle(
+    'single-document-project-store:commit-changes',
+    async (_, args: SingleDocumentProjectCommitChangesArgs) =>
+      runPromiseSerializingErrorsForIPC(
+        pipe(
+          validateProjectIdAndGetVersionedStores(args.projectId),
+          Effect.filterOrFail(
+            isSingleDocumentProjectVersionedStores,
+            () =>
+              new VersionedProjectValidationError(
+                `Invalid project store type. Expected a single-document project store for the given project ID.`
+              )
+          ),
+          Effect.flatMap(({ versionedProjectStore }) =>
+            versionedProjectStore.commitChanges(args)
           )
         )
       )

--- a/src/modules/domain/project/adapters/single-document-project/automerge/automerge-project-store/index.ts
+++ b/src/modules/domain/project/adapters/single-document-project/automerge/automerge-project-store/index.ts
@@ -274,6 +274,14 @@ export const createAdapter = (
         )
       );
 
+  // TODO: Implement explicit commit in Automerge
+  const commitChanges: SingleDocumentProjectStore['commitChanges'] = () =>
+    Effect.fail(
+      new RepositoryError(
+        'Explicit commit is not yet supported when the app is configured with Automerge'
+      )
+    );
+
   return {
     // TODO: Implement branching in Automerge
     supportsBranching: false,
@@ -289,6 +297,7 @@ export const createAdapter = (
     mergeAndDeleteBranch,
     getMergeConflictInfo,
     abortMerge,
+    commitChanges,
     commitMergeConflictsResolution,
     setAuthorInfo,
     addRemoteProject,

--- a/src/modules/domain/project/adapters/single-document-project/git/electron-renderer-ipc-project-store/index.ts
+++ b/src/modules/domain/project/adapters/single-document-project/git/electron-renderer-ipc-project-store/index.ts
@@ -199,6 +199,18 @@ export const createAdapter = (projId: string): SingleDocumentProjectStore => ({
       >,
       RepositoryError
     )(window.singleDocumentProjectStoreAPI.abortMerge(...args)),
+  commitChanges: (
+    ...args: Parameters<SingleDocumentProjectStore['commitChanges']>
+  ) =>
+    effectifyIPCPromise(
+      {
+        [VersionedProjectValidationErrorTag]: ValidationError,
+        [VersionedProjectRepositoryErrorTag]: RepositoryError,
+      } as ErrorRegistry<
+        EffectErrorType<ReturnType<SingleDocumentProjectStore['commitChanges']>>
+      >,
+      RepositoryError
+    )(window.singleDocumentProjectStoreAPI.commitChanges(...args)),
   commitMergeConflictsResolution: (
     ...args: Parameters<
       SingleDocumentProjectStore['commitMergeConflictsResolution']

--- a/src/modules/domain/project/adapters/single-document-project/git/git-project-store/index.ts
+++ b/src/modules/domain/project/adapters/single-document-project/git/git-project-store/index.ts
@@ -29,6 +29,7 @@ import {
   pullFromRemote as pullFromRemoteGitRepo,
   pushToRemote as pushToRemoteGitRepo,
   setUserInfo as setUserInfoInGit,
+  stageAndCommitWorkdirChanges,
   switchToBranch as switchToBranchWithGit,
   validateAndAddRemote,
   VersionControlNotFoundErrorTag,
@@ -313,6 +314,20 @@ export const createAdapter = ({
         )
       );
 
+  const commitChanges: SingleDocumentProjectStore['commitChanges'] = ({
+    message,
+  }) =>
+    pipe(
+      stageAndCommitWorkdirChanges({
+        isoGitFs,
+        dir: internalProjectDir,
+        message,
+      }),
+      Effect.catchTag(VersionControlRepositoryErrorTag, (err) =>
+        Effect.fail(new RepositoryError(err.message))
+      )
+    );
+
   const setAuthorInfo: SingleDocumentProjectStore['setAuthorInfo'] = ({
     username,
     email,
@@ -500,6 +515,7 @@ export const createAdapter = ({
     mergeAndDeleteBranch,
     getMergeConflictInfo,
     abortMerge,
+    commitChanges,
     commitMergeConflictsResolution,
     setAuthorInfo,
     addRemoteProject,

--- a/src/modules/domain/project/ports/single-document-project/single-document-project-store.ts
+++ b/src/modules/domain/project/ports/single-document-project/single-document-project-store.ts
@@ -29,6 +29,11 @@ export type CreateSingleDocumentProjectArgs = {
   authToken?: string;
 } & UserInfo;
 
+export type SingleDocumentProjectCommitChangesArgs = {
+  projectId: ProjectId;
+  message: string;
+};
+
 export type SingleDocumentProjectCreateAndSwitchToBranchArgs = {
   projectId: ProjectId;
   branch: Branch;
@@ -148,6 +153,9 @@ export type SingleDocumentProjectStore = {
     ValidationError | RepositoryError | NotFoundError | MigrationError,
     never
   >;
+  commitChanges: (
+    args: SingleDocumentProjectCommitChangesArgs
+  ) => Effect.Effect<Commit['id'], ValidationError | RepositoryError, never>;
   createAndSwitchToBranch: (
     args: SingleDocumentProjectCreateAndSwitchToBranchArgs
   ) => Effect.Effect<void, ValidationError | RepositoryError, never>;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -325,6 +325,10 @@ contextBridge.exposeInMainWorld('singleDocumentProjectStoreAPI', {
     ipcRenderer.invoke('single-document-project-store:abort-merge', {
       ...args,
     }),
+  commitChanges: (args) =>
+    ipcRenderer.invoke('single-document-project-store:commit-changes', {
+      ...args,
+    }),
   commitMergeConflictsResolution: (args) =>
     ipcRenderer.invoke(
       'single-document-project-store:commit-merge-conflicts-resolution',

--- a/src/renderer/src/app-state/commit-modal/context.tsx
+++ b/src/renderer/src/app-state/commit-modal/context.tsx
@@ -1,0 +1,41 @@
+import { createContext, useState } from 'react';
+
+export type CommitModalContextType = {
+  isOpen: boolean;
+  openCommitModal: () => void;
+  closeCommitModal: () => void;
+};
+
+export const CommitModalContext = createContext<CommitModalContextType>({
+  isOpen: false,
+  openCommitModal: () => {},
+  closeCommitModal: () => {},
+});
+
+export const CommitModalProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const openCommitModal = () => {
+    setIsOpen(true);
+  };
+
+  const closeCommitModal = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <CommitModalContext.Provider
+      value={{
+        isOpen,
+        openCommitModal,
+        closeCommitModal,
+      }}
+    >
+      {children}
+    </CommitModalContext.Provider>
+  );
+};

--- a/src/renderer/src/app-state/current-document/context.tsx
+++ b/src/renderer/src/app-state/current-document/context.tsx
@@ -57,6 +57,7 @@ import {
 import { useCurrentDocumentId } from '../../hooks/use-current-document-id';
 import { usePulledUpstreamChanges } from '../../hooks/use-pulled-upstream-changes';
 import {
+  CommitModalContext,
   CurrentProjectContext,
   InfrastructureAdaptersContext,
   MultiDocumentProjectContext,
@@ -73,14 +74,12 @@ export type CurrentDocumentContextType = {
   versionedDocumentHistory: ChangeWithUrlInfo[];
   canCommit: boolean;
   commitChangesToDocument: (message: string) => Promise<void>;
+  reloadDocumentHistory: () => Promise<void>;
   onRestoreCommit: (args: { message: string; commit: Commit }) => Promise<void>;
   onDiscardChanges: () => Promise<void>;
-  isCommitDialogOpen: boolean;
   commitToRestore: Commit | null;
   isRestoreCommitDialogOpen: boolean;
   isDiscardChangesDialogOpen: boolean;
-  onOpenCommitDialog: () => void;
-  onCloseCommitDialog: () => void;
   onOpenRestoreCommitDialog: (commit: Commit) => void;
   onCloseRestoreCommitDialog: () => void;
   onOpenDiscardChangesDialog: () => void;
@@ -105,14 +104,12 @@ export const CurrentDocumentContext = createContext<CurrentDocumentContextType>(
     versionedDocumentHistory: [],
     canCommit: false,
     commitChangesToDocument: async () => {},
+    reloadDocumentHistory: async () => {},
     onRestoreCommit: async () => {},
     onDiscardChanges: async () => {},
-    isCommitDialogOpen: false,
     isRestoreCommitDialogOpen: false,
     isDiscardChangesDialogOpen: false,
     commitToRestore: null,
-    onOpenCommitDialog: () => {},
-    onCloseCommitDialog: () => {},
     onOpenRestoreCommitDialog: () => {},
     onCloseRestoreCommitDialog: () => {},
     onOpenDiscardChangesDialog: () => {},
@@ -148,7 +145,7 @@ export const CurrentDocumentProvider = ({
   >([]);
   const [lastCommit, setLastCommit] = useState<Commit | null>(null);
   const [canCommit, setCanCommit] = useState(false);
-  const [isCommitDialogOpen, setIsCommitDialogOpen] = useState<boolean>(false);
+  const { closeCommitModal } = useContext(CommitModalContext);
   const [isRestoreCommitDialogOpen, setIsRestoreCommitDialogOpen] =
     useState<boolean>(false);
   const [isDiscardChangesDialogOpen, setIsDiscardChangesDialogOpen] =
@@ -397,6 +394,14 @@ export const CurrentDocumentProvider = ({
     }
   }, [versionedDocumentHistory, changeIdParam]);
 
+  const reloadDocumentHistory = useCallback(async () => {
+    if (!versionedDocumentStore || !versionedDocument || !documentId) return;
+    await loadHistory(versionedDocumentStore)({
+      doc: versionedDocument,
+      docId: documentId,
+    });
+  }, [versionedDocumentStore, versionedDocument, documentId]);
+
   const handleCommit = useCallback(
     async (message: string) => {
       if (!documentId || !versionedDocumentStore) {
@@ -410,16 +415,16 @@ export const CurrentDocumentProvider = ({
         })
       );
 
-      setIsCommitDialogOpen(false);
+      closeCommitModal();
 
-      if (versionedDocument) {
-        await loadHistory(versionedDocumentStore)({
-          doc: versionedDocument,
-          docId: documentId,
-        });
-      }
+      await reloadDocumentHistory();
     },
-    [documentId, versionedDocument, versionedDocumentStore]
+    [
+      documentId,
+      versionedDocumentStore,
+      closeCommitModal,
+      reloadDocumentHistory,
+    ]
   );
 
   const handleRestoreCommit = useCallback(
@@ -539,14 +544,6 @@ export const CurrentDocumentProvider = ({
     documentChangeSubRouteMatch,
     documentRouteMatch,
   ]);
-
-  const handleOpenCommitDialog = useCallback(() => {
-    setIsCommitDialogOpen(true);
-  }, []);
-
-  const handleCloseCommitDialog = useCallback(() => {
-    setIsCommitDialogOpen(false);
-  }, []);
 
   const handleOpenRestoreCommitDialog = useCallback((commit: Commit) => {
     setIsRestoreCommitDialogOpen(true);
@@ -831,14 +828,12 @@ export const CurrentDocumentProvider = ({
         versionedDocumentHistory,
         canCommit,
         commitChangesToDocument: handleCommit,
+        reloadDocumentHistory,
         onRestoreCommit: handleRestoreCommit,
         onDiscardChanges: handleDiscardChanges,
-        isCommitDialogOpen,
         commitToRestore,
         isRestoreCommitDialogOpen,
         isDiscardChangesDialogOpen,
-        onOpenCommitDialog: handleOpenCommitDialog,
-        onCloseCommitDialog: handleCloseCommitDialog,
         onOpenRestoreCommitDialog: handleOpenRestoreCommitDialog,
         onCloseRestoreCommitDialog: handleCloseRestoreCommitDialog,
         onOpenDiscardChangesDialog: handleOpenDiscardChangesDialog,

--- a/src/renderer/src/app-state/current-project/single-document-project-context.tsx
+++ b/src/renderer/src/app-state/current-project/single-document-project-context.tsx
@@ -95,6 +95,7 @@ export type SingleDocumentProjectContextType = {
   pullFromRemoteProject: () => Promise<void>;
   pulledUpstreamChanges: boolean;
   onHandlePulledUpstreamChanges: () => void;
+  commitChanges: (message: string) => Promise<void>;
 };
 
 export const SingleDocumentProjectContext =
@@ -111,6 +112,7 @@ export const SingleDocumentProjectContext =
     openDocument: () => null,
     versionedProjectStore: null,
     isCreateBranchDialogOpen: false,
+    commitChanges: async () => {},
   });
 
 const getFileToBeOpenedFromSessionStorage = (): File | null => {
@@ -808,6 +810,20 @@ export const SingleDocumentProjectProvider = ({
     setPulledUpstreamChanges(false);
   };
 
+  const handleCommitChanges = useCallback(
+    async (message: string) => {
+      if (!versionedProjectStore || !projectId) {
+        throw new Error(
+          'Project store is not ready or project has not been set yet. Cannot commit changes.'
+        );
+      }
+      await Effect.runPromise(
+        versionedProjectStore.commitChanges({ projectId, message })
+      );
+    },
+    [versionedProjectStore, projectId]
+  );
+
   return (
     <SingleDocumentProjectContext.Provider
       value={{
@@ -844,6 +860,7 @@ export const SingleDocumentProjectProvider = ({
         pullFromRemoteProject: handlePullFromRemoteProject,
         pulledUpstreamChanges,
         onHandlePulledUpstreamChanges: resetPulledUpstreamChanges,
+        commitChanges: handleCommitChanges,
       }}
     >
       {children}

--- a/src/renderer/src/app-state/index.ts
+++ b/src/renderer/src/app-state/index.ts
@@ -48,6 +48,12 @@ export {
 } from './create-document-modal/context';
 
 export {
+  CommitModalContext,
+  type CommitModalContextType,
+  CommitModalProvider,
+} from './commit-modal/context';
+
+export {
   SidebarLayoutContext,
   type SidebarLayoutContextType,
   SidebarLayoutProvider,

--- a/src/renderer/src/hooks/index.ts
+++ b/src/renderer/src/hooks/index.ts
@@ -16,3 +16,4 @@ export * from './use-branch-info';
 export * from './use-project-id';
 export * from './use-pulled-upstream-changes';
 export * from './use-remote-project-info';
+export * from './use-commit-to-project';

--- a/src/renderer/src/hooks/use-commit-to-project.ts
+++ b/src/renderer/src/hooks/use-commit-to-project.ts
@@ -1,0 +1,37 @@
+import { useCallback, useContext } from 'react';
+
+import { projectTypes } from '../../../modules/domain/project';
+import {
+  CommitModalContext,
+  CurrentDocumentContext,
+  CurrentProjectContext,
+  MultiDocumentProjectContext,
+  SingleDocumentProjectContext,
+} from '../app-state';
+
+export const useCommitToProject = () => {
+  const { projectType } = useContext(CurrentProjectContext);
+  const { commitChanges: multiDocumentCommitChanges } = useContext(
+    MultiDocumentProjectContext
+  );
+  const { commitChanges: singleDocumentCommitChanges } = useContext(
+    SingleDocumentProjectContext
+  );
+  const { closeCommitModal } = useContext(CommitModalContext);
+  const { reloadDocumentHistory } = useContext(CurrentDocumentContext);
+
+  const commit =
+    projectType === projectTypes.MULTI_DOCUMENT_PROJECT
+      ? multiDocumentCommitChanges
+      : singleDocumentCommitChanges;
+
+  return useCallback(
+    async (message: string) => {
+      await commit(message);
+      closeCommitModal();
+      // No-op when there is no active document.
+      await reloadDocumentHistory();
+    },
+    [commit, closeCommitModal, reloadDocumentHistory]
+  );
+};

--- a/src/renderer/src/pages/project/current-project/change-dialogs/CommitDialog.tsx
+++ b/src/renderer/src/pages/project/current-project/change-dialogs/CommitDialog.tsx
@@ -1,33 +1,44 @@
 import React, { useState } from 'react';
 
 import { Button } from '../../../../components/actions/Button';
+import { SplitButton } from '../../../../components/actions/SplitButton';
 import { Modal } from '../../../../components/dialogs/Modal';
 import { CheckIcon } from '../../../../components/icons/Check';
 import { Textarea } from '../../../../components/inputs/Textarea';
+
+export type CommitOption = {
+  label: string;
+  description?: string;
+  onCommit: (message: string) => void;
+};
 
 type CommitDialogProps = {
   isOpen?: boolean;
   onCancel?: () => void;
   canCommit: boolean;
-  onCommit: (message: string) => void;
+  primaryAction: CommitOption;
+  secondaryActions?: CommitOption[];
 };
 
 export const CommitDialog = ({
   isOpen = false,
   onCancel,
   canCommit,
-  onCommit,
+  primaryAction,
+  secondaryActions = [],
 }: CommitDialogProps) => {
   const [commitMessage, setCommitMessage] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
 
-  const handleCommitSubmission = () => {
+  const submit = (handler: (message: string) => void) => {
     if (commitMessage.length === 0) {
       return setErrorMessage('Commit message cannot be empty.');
     }
-    onCommit(commitMessage);
+    handler(commitMessage);
     setCommitMessage('');
   };
+
+  const handlePrimary = () => submit(primaryAction.onCommit);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     // on Escape key press
@@ -35,12 +46,41 @@ export const CommitDialog = ({
       setCommitMessage('');
       onCancel();
     }
-    // on cmd/ctrl + enter --> submit the commit
+    // on cmd/ctrl + enter --> submit the primary commit action
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
       e.preventDefault();
-      handleCommitSubmission();
+      handlePrimary();
     }
   };
+
+  const primaryButton =
+    secondaryActions.length > 0 ? (
+      <SplitButton
+        primaryLabel={
+          <>
+            <CheckIcon />
+            Commit
+          </>
+        }
+        onPrimaryClick={handlePrimary}
+        primaryTooltip={primaryAction.description ?? primaryAction.label}
+        disabled={!canCommit}
+        color="purple"
+        toggleAriaLabel="More commit options"
+        menuLabel="Other commit options"
+        menuItems={secondaryActions.map((action) => ({
+          label: action.label,
+          description: action.description,
+          onClick: () => submit(action.onCommit),
+          disabled: !canCommit,
+        }))}
+      />
+    ) : (
+      <Button onClick={handlePrimary} color="purple" disabled={!canCommit}>
+        <CheckIcon />
+        Commit
+      </Button>
+    );
 
   return (
     <Modal
@@ -51,16 +91,7 @@ export const CommitDialog = ({
           Cancel
         </Button>
       }
-      primaryButton={
-        <Button
-          onClick={handleCommitSubmission}
-          color="purple"
-          disabled={!canCommit}
-        >
-          <CheckIcon />
-          Commit
-        </Button>
-      }
+      primaryButton={primaryButton}
     >
       <Textarea
         className="h-full w-full resize-none border-gray-400 shadow-inner outline-none"

--- a/src/renderer/src/pages/project/current-project/documents/main/editor/DocumentEditor.tsx
+++ b/src/renderer/src/pages/project/current-project/documents/main/editor/DocumentEditor.tsx
@@ -2,6 +2,7 @@ import { useCallback, useContext, useState } from 'react';
 
 import { ProseMirrorContext } from '../../../../../../../../modules/domain/rich-text/react/prosemirror-context';
 import {
+  CommitModalContext,
   CurrentDocumentContext,
   SidebarLayoutContext,
 } from '../../../../../../app-state';
@@ -18,9 +19,9 @@ export const DocumentEditor = () => {
     versionedDocument,
     versionedDocumentHandle,
     onDocumentContentChange,
-    onOpenCommitDialog,
     canCommit,
   } = useContext(CurrentDocumentContext);
+  const { openCommitModal } = useContext(CommitModalContext);
   const { isSidebarOpen, toggleSidebar } = useContext(SidebarLayoutContext);
   const { isUnsupported } = useCurrentDocumentExtension();
 
@@ -41,7 +42,7 @@ export const DocumentEditor = () => {
           onSidebarToggle={toggleSidebar}
           onEditorToolbarToggle={handleEditorToolbarToggle}
           canCommit={canCommit}
-          onCheckIconClick={onOpenCommitDialog}
+          onCheckIconClick={openCommitModal}
         />
       </div>
 

--- a/src/renderer/src/pages/project/current-project/documents/main/history/DocumentHistoricalView.tsx
+++ b/src/renderer/src/pages/project/current-project/documents/main/history/DocumentHistoricalView.tsx
@@ -5,7 +5,10 @@ import {
   changeIdsAreSame,
   isCommit,
 } from '../../../../../../../../modules/infrastructure/version-control';
-import { CurrentDocumentContext } from '../../../../../../app-state';
+import {
+  CommitModalContext,
+  CurrentDocumentContext,
+} from '../../../../../../app-state';
 import { IconButton } from '../../../../../../components/actions/IconButton';
 import {
   CheckIcon,
@@ -77,10 +80,10 @@ export const DocumentHistoricalView = () => {
   const {
     versionedDocumentHistory: commits,
     onSelectChange,
-    onOpenCommitDialog,
     onOpenRestoreCommitDialog,
     onOpenDiscardChangesDialog,
   } = useContext(CurrentDocumentContext);
+  const { openCommitModal } = useContext(CommitModalContext);
   const currentDocumentName = useCurrentDocumentName();
 
   const {
@@ -132,7 +135,7 @@ export const DocumentHistoricalView = () => {
     <UncommittedChangesActions
       onEdit={navigateToEdit}
       onDiscard={onOpenDiscardChangesDialog}
-      onCommit={onOpenCommitDialog}
+      onCommit={openCommitModal}
       canDiscard={commits.length > 1}
     />
   ) : (

--- a/src/renderer/src/pages/project/current-project/history/ProjectHistoryPage.tsx
+++ b/src/renderer/src/pages/project/current-project/history/ProjectHistoryPage.tsx
@@ -228,7 +228,11 @@ export const ProjectHistoryPage = () => {
         isOpen={isCommitDialogOpen}
         onCancel={handleCancelCommitDialog}
         canCommit={uncommittedChanges.length > 0}
-        onCommit={handleCommit}
+        primaryAction={{
+          label: 'Commit all project changes',
+          description: 'Commit every modified file in the project',
+          onCommit: handleCommit,
+        }}
       />
     </>
   );

--- a/src/renderer/src/pages/project/current-project/index.tsx
+++ b/src/renderer/src/pages/project/current-project/index.tsx
@@ -1,17 +1,23 @@
 import { useContext, useEffect } from 'react';
 import { Outlet, useNavigate } from 'react-router';
 
-import { urlEncodeProjectId } from '../../../../../modules/domain/project';
+import {
+  projectTypes,
+  urlEncodeProjectId,
+} from '../../../../../modules/domain/project';
 import { removePath } from '../../../../../modules/infrastructure/filesystem';
 import { urlEncodeArtifactId } from '../../../../../modules/infrastructure/version-control';
 import {
   BranchingCommandPaletteContext,
+  CommitModalContext,
   CreateDocumentModalContext,
   CurrentDocumentContext,
+  CurrentProjectContext,
 } from '../../../app-state';
 import { BranchingCommandPaletteStateProvider } from '../../../app-state';
 import {
   useBranchInfo,
+  useCommitToProject,
   useCreateDocument,
   useDeleteDirectory,
   useDeleteDocument,
@@ -46,8 +52,6 @@ export const CurrentProject = () => {
 const Project = () => {
   const {
     versionedDocumentId,
-    onCloseCommitDialog,
-    isCommitDialogOpen,
     isRestoreCommitDialogOpen,
     isDiscardChangesDialogOpen,
     canCommit,
@@ -57,6 +61,15 @@ const Project = () => {
     onRestoreCommit,
     onDiscardChanges,
   } = useContext(CurrentDocumentContext);
+  const { isOpen: isCommitDialogOpen, closeCommitModal } =
+    useContext(CommitModalContext);
+  const commitChangesToProject = useCommitToProject();
+  const { projectType } = useContext(CurrentProjectContext);
+  // For single-document projects the project-level commit is the same
+  // operation as committing the (sole) document, so we don't surface it as
+  // a separate option in the commit dialog.
+  const showProjectCommitOption =
+    projectType === projectTypes.MULTI_DOCUMENT_PROJECT;
   const navigate = useNavigate();
   const {
     isOpen: isBranchingCommandPaletteOpen,
@@ -123,9 +136,26 @@ const Project = () => {
         />
         <CommitDialog
           isOpen={isCommitDialogOpen}
-          onCancel={onCloseCommitDialog}
+          onCancel={closeCommitModal}
           canCommit={canCommit}
-          onCommit={(message: string) => commitChangesToDocument(message)}
+          primaryAction={{
+            label: 'Commit document',
+            description:
+              'Commit changes to this document and its referenced assets',
+            onCommit: (message: string) => commitChangesToDocument(message),
+          }}
+          secondaryActions={
+            showProjectCommitOption
+              ? [
+                  {
+                    label: 'Commit all project changes',
+                    description: 'Commit every modified file in the project',
+                    onCommit: (message: string) =>
+                      commitChangesToProject(message),
+                  },
+                ]
+              : []
+          }
         />
         <RestoreCommitDialog
           isOpen={isRestoreCommitDialogOpen}

--- a/src/renderer/src/pages/project/providers/index.tsx
+++ b/src/renderer/src/pages/project/providers/index.tsx
@@ -5,6 +5,7 @@ import { ProseMirrorProvider } from '../../../../../modules/domain/rich-text/rea
 import { ElectronContext } from '../../../../../modules/infrastructure/cross-platform/browser';
 import {
   CloneFromGithubModalProvider,
+  CommitModalProvider,
   CreateDocumentModalProvider,
   CurrentDocumentProvider,
   CurrentProjectProvider,
@@ -16,17 +17,19 @@ export const ProjectProviders = () => {
 
   return (
     <CurrentProjectProvider projectType={config.projectType}>
-      <CurrentDocumentProvider>
-        <CloneFromGithubModalProvider>
-          <CreateDocumentModalProvider>
-            <ProseMirrorProvider>
-              <SidebarLayoutProvider>
-                <Outlet />
-              </SidebarLayoutProvider>
-            </ProseMirrorProvider>
-          </CreateDocumentModalProvider>
-        </CloneFromGithubModalProvider>
-      </CurrentDocumentProvider>
+      <CommitModalProvider>
+        <CurrentDocumentProvider>
+          <CloneFromGithubModalProvider>
+            <CreateDocumentModalProvider>
+              <ProseMirrorProvider>
+                <SidebarLayoutProvider>
+                  <Outlet />
+                </SidebarLayoutProvider>
+              </ProseMirrorProvider>
+            </CreateDocumentModalProvider>
+          </CloneFromGithubModalProvider>
+        </CurrentDocumentProvider>
+      </CommitModalProvider>
     </CurrentProjectProvider>
   );
 };

--- a/src/renderer/src/pages/project/shared/command-palette/index.tsx
+++ b/src/renderer/src/pages/project/shared/command-palette/index.tsx
@@ -6,6 +6,7 @@ import { ElectronContext } from '../../../../../../modules/infrastructure/cross-
 import { removeExtension } from '../../../../../../modules/infrastructure/filesystem';
 import {
   CommandPaletteContext,
+  CommitModalContext,
   CurrentDocumentContext,
   CurrentProjectContext,
 } from '../../../../app-state';
@@ -38,8 +39,10 @@ export const ProjectCommandPalette = ({
     CommandPaletteContext
   );
   const { projectType } = useContext(CurrentProjectContext);
-  const { canCommit, onOpenCommitDialog, onOpenDiscardChangesDialog } =
-    useContext(CurrentDocumentContext);
+  const { canCommit, onOpenDiscardChangesDialog } = useContext(
+    CurrentDocumentContext
+  );
+  const { openCommitModal } = useContext(CommitModalContext);
   const { isElectron, checkForUpdate } = useContext(ElectronContext);
 
   const handleDocumentSelectionInMultiDocumentProject =
@@ -113,7 +116,7 @@ export const ProjectCommandPalette = ({
           {
             name: keyBindings.ctrlS.command,
             shortcut: keyBindings.ctrlS.keyBinding,
-            onActionSelection: onOpenCommitDialog,
+            onActionSelection: openCommitModal,
           },
           {
             name: 'Discard changes',


### PR DESCRIPTION
## Description

Adds a split button which enables the user to commit all project changes into the document commit dialog.

## Related Issue

Closes #352 

## Screenshots (_if applicable_)

<img width="2550" height="808" alt="Screenshot 2026-04-30 at 3 06 33 PM" src="https://github.com/user-attachments/assets/7b3b0613-a816-4275-a573-2dfdd39954b3" />