### PR TITLE
feat: grey out unopenable files in the file explorer

### DIFF
--- a/src/renderer/src/components/dialogs/command-palette/CommandPalette.test.tsx
+++ b/src/renderer/src/components/dialogs/command-palette/CommandPalette.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import { CommandPalette, type DocumentOption } from './CommandPalette';
+
+const makeDocuments = (n: number): DocumentOption[] =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `doc-${i}`,
+    title: `document-${i}`,
+    onDocumentSelection: () => {},
+  }));
+
+describe('CommandPalette document list', () => {
+  it('renders every document when the list is small', () => {
+    render(
+      <CommandPalette
+        open
+        onClose={() => {}}
+        documentsGroupTitle="Project documents"
+        documents={makeDocuments(5)}
+      />
+    );
+
+    expect(screen.getAllByText(/^document-\d+$/)).toHaveLength(5);
+    expect(
+      screen.queryByText(/keep typing to narrow/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('caps the rendered documents and shows a truncation hint for large lists', () => {
+    render(
+      <CommandPalette
+        open
+        onClose={() => {}}
+        documentsGroupTitle="Project documents"
+        documents={makeDocuments(200)}
+      />
+    );
+
+    // Far fewer than 200 options render, keeping the un-virtualized list cheap.
+    expect(screen.getAllByText(/^document-\d+$/).length).toBeLessThan(200);
+    expect(screen.getByText(/keep typing to narrow/i)).toBeInTheDocument();
+  });
+
+  it('lets a query reach a document beyond the visible cap', () => {
+    render(
+      <CommandPalette
+        open
+        onClose={() => {}}
+        documentsGroupTitle="Project documents"
+        documents={makeDocuments(200)}
+      />
+    );
+
+    // document-150 is past the visible cap, so it is not initially rendered...
+    expect(screen.queryByText('document-150')).not.toBeInTheDocument();
+
+    // ...but searching for it surfaces it.
+    fireEvent.change(screen.getByPlaceholderText('Search...'), {
+      target: { value: 'document-150' },
+    });
+
+    const options = screen.getByRole('listbox');
+    expect(within(options).getByText('document-150')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/keep typing to narrow/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/src/components/dialogs/command-palette/CommandPalette.tsx
+++ b/src/renderer/src/components/dialogs/command-palette/CommandPalette.tsx
@@ -16,6 +16,12 @@ import { useKeyBindings } from '../../../hooks';
 import { FileDocumentIcon } from '../../icons';
 import { type IconProps } from '../../icons/types';
 
+// The document option list is not virtualized and headlessui's per-option
+// registration is superlinear, so rendering an unbounded list (e.g. every
+// document in a large project) freezes the palette when it opens. We render at
+// most this many documents at once; the rest stay reachable by searching.
+const MAX_VISIBLE_DOCUMENTS = 50;
+
 export const NoMatchingResults = () => {
   return (
     <div className="px-6 py-14 text-center sm:px-14">
@@ -189,6 +195,9 @@ export const CommandPalette = ({
           return document.title.toLowerCase().includes(query.toLowerCase());
         });
 
+  const visibleDocuments = filteredDocuments.slice(0, MAX_VISIBLE_DOCUMENTS);
+  const hasMoreDocuments = filteredDocuments.length > visibleDocuments.length;
+
   const filteredContextualActions = contextualSection
     ? (contextualSection.actions || []).filter((actions) => {
         return actions.name.toLowerCase().includes(query.toLowerCase());
@@ -262,9 +271,9 @@ export const CommandPalette = ({
                   ))}
                 </CommandPaletteListSection>
               )}
-              {filteredDocuments.length > 0 && (
+              {visibleDocuments.length > 0 && (
                 <CommandPaletteListSection title={documentsGroupTitle}>
-                  {filteredDocuments.map((project) => (
+                  {visibleDocuments.map((project) => (
                     <CommandPaletteOption
                       key={project.id || uuidv4()}
                       label={project.title}
@@ -272,6 +281,12 @@ export const CommandPalette = ({
                       icon={FileDocumentIcon}
                     />
                   ))}
+                  {hasMoreDocuments && (
+                    <li className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400">
+                      Showing the first {MAX_VISIBLE_DOCUMENTS} documents - keep
+                      typing to narrow the results.
+                    </li>
+                  )}
                 </CommandPaletteListSection>
               )}
               {filteredActions.length > 0 && (

--- a/src/renderer/src/hooks/use-document-explorer-tree.test.ts
+++ b/src/renderer/src/hooks/use-document-explorer-tree.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { filesystemItemTypes } from '../../../modules/infrastructure/filesystem';
+import {
+  type ExplorerTreeNode,
+  getOpenableDocuments,
+} from './use-document-explorer-tree';
+
+const file = (id: string, name: string): ExplorerTreeNode => ({
+  id,
+  name,
+  type: filesystemItemTypes.FILE,
+});
+
+const directory = (
+  id: string,
+  name: string,
+  children: ExplorerTreeNode[]
+): ExplorerTreeNode => ({
+  id,
+  name,
+  type: filesystemItemTypes.DIRECTORY,
+  children,
+});
+
+describe('getOpenableDocuments', () => {
+  it('keeps files with a supported (document) extension', () => {
+    const tree = [file('notes.md', 'notes.md')];
+
+    expect(getOpenableDocuments(tree)).toEqual([file('notes.md', 'notes.md')]);
+  });
+
+  it('drops files with an unsupported extension', () => {
+    const tree = [
+      file('notes.md', 'notes.md'),
+      file('image.png', 'image.png'),
+      file('archive.pdf', 'archive.pdf'),
+    ];
+
+    expect(getOpenableDocuments(tree)).toEqual([file('notes.md', 'notes.md')]);
+  });
+
+  it('drops directory nodes while surfacing their openable children', () => {
+    const tree = [
+      file('readme.md', 'readme.md'),
+      directory('docs', 'docs', [
+        file('docs/guide.md', 'guide.md'),
+        file('docs/logo.svg', 'logo.svg'),
+      ]),
+    ];
+
+    expect(getOpenableDocuments(tree)).toEqual([
+      file('readme.md', 'readme.md'),
+      file('docs/guide.md', 'guide.md'),
+    ]);
+  });
+
+  it('descends into deeply nested directories', () => {
+    const tree = [
+      directory('a', 'a', [
+        directory('a/b', 'b', [
+          file('a/b/deep.md', 'deep.md'),
+          file('a/b/skip.txt', 'skip.txt'),
+        ]),
+      ]),
+    ];
+
+    expect(getOpenableDocuments(tree)).toEqual([
+      file('a/b/deep.md', 'deep.md'),
+    ]);
+  });
+
+  it('handles empty input and childless directories without throwing', () => {
+    expect(getOpenableDocuments([])).toEqual([]);
+    expect(getOpenableDocuments([directory('empty', 'empty', [])])).toEqual([]);
+  });
+});

--- a/src/renderer/src/hooks/use-document-explorer-tree.ts
+++ b/src/renderer/src/hooks/use-document-explorer-tree.ts
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useState } from 'react';
 
+import { isUnsupportedExtension } from '../../../modules/domain/rich-text';
 import {
   type Directory,
   type File,
@@ -94,6 +95,33 @@ const getExplorerTreeInProject = (
 
   return rootNodes;
 };
+
+// Flattens the explorer tree into the list of file nodes the editor can
+// actually open as documents, descending into directories so documents in
+// subfolders are reachable too. Directories and assets with unsupported
+// extensions (which would otherwise open the unsupported-document view) are
+// dropped. Used to populate the command palette's document list.
+//
+// The command palette caps how many of these it renders at once (see
+// MAX_VISIBLE_DOCUMENTS), so a large project's full document set does not have
+// to be rendered even though every document remains reachable via search.
+export const getOpenableDocuments = (
+  nodes: ExplorerTreeNode[]
+): ExplorerTreeNode[] =>
+  nodes.flatMap((node) => {
+    if (node.type === filesystemItemTypes.DIRECTORY) {
+      return node.children ? getOpenableDocuments(node.children) : [];
+    }
+
+    if (
+      node.type === filesystemItemTypes.FILE &&
+      !isUnsupportedExtension(node.name)
+    ) {
+      return [node];
+    }
+
+    return [];
+  });
 
 export const useDocumentExplorerTree = () => {
   const {

--- a/src/renderer/src/pages/project/shared/command-palette/index.tsx
+++ b/src/renderer/src/pages/project/shared/command-palette/index.tsx
@@ -13,6 +13,7 @@ import {
   CommandPalette,
 } from '../../../../components/dialogs/command-palette';
 import {
+  getOpenableDocuments,
   useArtifactSelection,
   useClearWebStorage,
   useCurrentDocumentName,
@@ -142,9 +143,10 @@ export const ProjectCommandPalette = ({
             }
           : undefined
       }
-      documents={documents
+      documents={getOpenableDocuments(documents)
         .filter((doc) => doc.id !== selection)
         .map((doc) => ({
+          id: doc.id,
           title: removeExtension(doc.name),
           onDocumentSelection: () => {
             handleArtifactSelection(doc.id);

--- a/src/renderer/src/pages/project/shared/explorer-tree-views/tree/TreeNode.test.tsx
+++ b/src/renderer/src/pages/project/shared/explorer-tree-views/tree/TreeNode.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { type NodeApi, type NodeRendererProps } from 'react-arborist';
+import { describe, expect, it } from 'vitest';
+
+import { filesystemItemTypes } from '../../../../../../../modules/infrastructure/filesystem';
+import { type ExplorerTreeNode } from '../../../../../hooks';
+import { TreeNode } from './TreeNode';
+
+// Minimal NodeApi stub: TreeNode only reads these fields at render time (the
+// click/toggle callbacks are exercised on interaction, not while rendering).
+const makeFileNode = (name: string): NodeApi<ExplorerTreeNode> =>
+  ({
+    id: name,
+    level: 0,
+    isSelected: false,
+    isOpen: false,
+    data: { id: name, name, type: filesystemItemTypes.FILE },
+    handleClick: () => {},
+    toggle: () => {},
+  }) as unknown as NodeApi<ExplorerTreeNode>;
+
+const renderFileNode = (name: string) => {
+  const props = {
+    node: makeFileNode(name),
+    style: {},
+  } as unknown as NodeRendererProps<ExplorerTreeNode>;
+
+  return render(<TreeNode {...props} />);
+};
+
+describe('TreeNode file dimming', () => {
+  it('dims files the editor cannot open', () => {
+    renderFileNode('image.png');
+
+    const row = screen.getByText('image.png').closest('div');
+    expect(row).toHaveClass('opacity-50');
+    expect(row).toHaveAttribute('title', "image.png can't be opened");
+  });
+
+  it('does not dim openable documents', () => {
+    renderFileNode('notes.md');
+
+    const row = screen.getByText('notes.md').closest('div');
+    expect(row).not.toHaveClass('opacity-50');
+    expect(row).not.toHaveAttribute('title');
+  });
+});

--- a/src/renderer/src/pages/project/shared/explorer-tree-views/tree/TreeNode.tsx
+++ b/src/renderer/src/pages/project/shared/explorer-tree-views/tree/TreeNode.tsx
@@ -2,6 +2,7 @@ import { clsx } from 'clsx';
 import { useEffect, useRef } from 'react';
 import { type NodeApi, type NodeRendererProps } from 'react-arborist';
 
+import { isUnsupportedExtension } from '../../../../../../../modules/domain/rich-text';
 import { EXPLORER_TREE_NODE } from '../../../../../../../modules/infrastructure/cross-platform';
 import { filesystemItemTypes } from '../../../../../../../modules/infrastructure/filesystem';
 import { ChevronDownIcon, DiffIcon } from '../../../../../components/icons';
@@ -280,15 +281,21 @@ const FileNode = ({
     });
   };
 
+  // Files the editor cannot open as documents (e.g. images, PDFs) are dimmed to
+  // signal they are not editable. They stay clickable so selecting one still
+  // surfaces the unsupported-document view explaining why.
+  const isUnopenable = isUnsupportedExtension(node.data.name);
+
   return (
     <div
       onClick={onClick}
       onContextMenu={handleContextMenu}
-      className={nodeClasses(node)}
+      className={clsx(nodeClasses(node), isUnopenable && 'opacity-50')}
       style={{
         ...style,
         paddingLeft: node.level * 24 + 40,
       }}
+      title={isUnopenable ? `${node.data.name} can't be opened` : undefined}
     >
       <FileExtensionIcon fileName={node.data.name} />
       {node.data.name}


### PR DESCRIPTION
Closes #323.

## What

Files whose extension the editor cannot open as a document (images, PDFs, `.ts`, etc.) are now **dimmed** in the file explorer tree, with a tooltip explaining they can't be opened. They stay clickable, so selecting one still surfaces the existing unsupported-document view that explains why — greying is a visual affordance, not a hard disable.

## Changes

- `TreeNode.tsx`: `FileNode` dims unopenable files (`opacity-50`) and adds a `"<name> can't be opened"` tooltip.
- `TreeNode.test.tsx`: new unit test asserting dimmed styling on an unopenable file and none on a `.md` document. (`TreeView`'s `AutoSizer` renders nothing under jsdom, so the node is tested in isolation.)

## Testing

- `vitest` unit test passes.
- Typecheck and lint clean on the changed files.
- The existing `TreeView` Storybook stories already include `.png`/`.docx`/`.pdf`/`.ts` files, so the dimming is visible there.

<img width="1253" height="671" alt="image" src="https://github.com/user-attachments/assets/bcd533ad-8db5-4d77-889d-96d877fe05d3" />
