### PR TITLE
fix: confirm branch deletion with the Enter key

### DIFF
--- a/src/renderer/src/pages/project/current-project/branching/DeleteBranchDialog.tsx
+++ b/src/renderer/src/pages/project/current-project/branching/DeleteBranchDialog.tsx
@@ -33,7 +33,7 @@ export const DeleteBranchDialog = ({
         </Button>
       }
       primaryButton={
-        <Button onClick={handleDeleteBranch} color="red">
+        <Button onClick={handleDeleteBranch} color="red" autoFocus>
           <TrashIcon />
           Delete
         </Button>

--- a/src/renderer/src/pages/project/current-project/change-dialogs/DeleteDirectoryDialog.tsx
+++ b/src/renderer/src/pages/project/current-project/change-dialogs/DeleteDirectoryDialog.tsx
@@ -24,7 +24,7 @@ export const DeleteDirectoryDialog = ({
       </Button>
     }
     primaryButton={
-      <Button onClick={onConfirm} color="red">
+      <Button onClick={onConfirm} color="red" autoFocus>
         <TrashIcon />
         Delete
       </Button>

--- a/src/renderer/src/pages/project/current-project/change-dialogs/DeleteDocumentDialog.tsx
+++ b/src/renderer/src/pages/project/current-project/change-dialogs/DeleteDocumentDialog.tsx
@@ -24,7 +24,7 @@ export const DeleteDocumentDialog = ({
       </Button>
     }
     primaryButton={
-      <Button onClick={onConfirm} color="red">
+      <Button onClick={onConfirm} color="red" autoFocus>
         <TrashIcon />
         Delete
       </Button>

--- a/src/renderer/src/pages/project/current-project/change-dialogs/DiscardChangesDialog.tsx
+++ b/src/renderer/src/pages/project/current-project/change-dialogs/DiscardChangesDialog.tsx
@@ -22,7 +22,7 @@ export const DiscardChangesDialog = ({
       </Button>
     }
     primaryButton={
-      <Button onClick={onDiscardChanges} color="red">
+      <Button onClick={onDiscardChanges} color="red" autoFocus>
         <TrashIcon />
         Discard
       </Button>


### PR DESCRIPTION
Fixes #377

The delete-branch dialog had no initially focused element, so pressing Enter had no target and did nothing. This adds `autoFocus` to the Delete button — Headless UI v2's Dialog moves initial focus to the element marked `data-autofocus` (which the Headless `Button` renders from the `autoFocus` prop), so Enter now activates Delete.

The same fix is applied to the other confirm-style dialogs with the same problem: `DeleteDocumentDialog`, `DeleteDirectoryDialog`, and `DiscardChangesDialog`. Dialogs with text inputs (create branch, commit, restore commit, etc.) already autofocus their input and handle Enter/Ctrl+Enter, so they are unchanged.