### PR TITLE
fix: select the Edit nav item when clicking on the v2 logo

### DIFF
--- a/src/renderer/src/components/navigation/NavBar.test.tsx
+++ b/src/renderer/src/components/navigation/NavBar.test.tsx
@@ -20,12 +20,14 @@ describe('NavBar', () => {
       expect(screen.getByTestId('nav-bar')).toBeInTheDocument();
     });
 
-    it('renders the logo linking to projects', () => {
+    it('renders the logo linking to the edit view', () => {
       render(<Project />);
 
       const logoLink = screen
         .getByTestId('nav-bar')
-        .querySelector('a[href="/projects"]');
+        .querySelector(
+          `a[href="/projects/${encodeURIComponent(projectId)}/artifacts"]`
+        );
       expect(logoLink).toBeInTheDocument();
       expect(logoLink?.querySelector('svg')).toBeInTheDocument();
     });

--- a/src/renderer/src/components/navigation/NavBar.tsx
+++ b/src/renderer/src/components/navigation/NavBar.tsx
@@ -74,15 +74,17 @@ export function NavBar() {
     (projectMatch?.params.projectId as ProjectId | undefined) ?? null;
   const projectId = projectIdFromUrl ?? getStoredProjectId();
 
+  const editHref = getProjectSubroute({
+    subpath: 'artifacts',
+    fallback: '/projects',
+    projectId,
+  });
+
   const projectSpecificNavItems: NavItem[] = useMemo(
     () => [
       {
         name: 'Edit',
-        href: getProjectSubroute({
-          subpath: 'artifacts',
-          fallback: '/projects',
-          projectId,
-        }),
+        href: editHref,
         icon: PenIcon,
         current: true,
       },
@@ -97,7 +99,7 @@ export function NavBar() {
         current: false,
       },
     ],
-    [projectId]
+    [editHref, projectId]
   );
 
   const appWideNavItems: NavItem[] = [
@@ -114,7 +116,7 @@ export function NavBar() {
       className="flex h-full w-12 flex-none flex-col items-center gap-y-5 overflow-y-auto border-r border-gray-300 bg-transparent py-4 dark:border-neutral-600"
       data-testid="nav-bar"
     >
-      <NavLink to="/projects">
+      <NavLink to={editHref}>
         <Logo />
       </NavLink>
 


### PR DESCRIPTION
Fixes #376

The logo linked to `/projects` while the Edit nav item links to `/projects/:projectId/artifacts`, so after clicking the logo no nav item appeared selected. The logo now links to the same route as the Edit item (falling back to `/projects` when no project is open, where Edit also points), so the Edit `NavLink` matches the route and renders as active.

Updated the NavBar test accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)