### PR TITLE
Model directories as merely structural components, not artifacts

### DIFF
--- a/src/modules/domain/project/adapters/git/git-project-store/directories.test.ts
+++ b/src/modules/domain/project/adapters/git/git-project-store/directories.test.ts
@@ -9,17 +9,14 @@ import {
   RepositoryError as FilesystemRepositoryError,
   toDirectory,
 } from '../../../../../infrastructure/filesystem';
-import {
-  createGitBlobRef,
-  createGitTreeRef,
-} from '../../../../../infrastructure/version-control';
+import { createGitBlobRef } from '../../../../../infrastructure/version-control';
 import {
   NotFoundError,
   RepositoryError,
   VersionedProjectNotFoundErrorTag,
   VersionedProjectRepositoryErrorTag,
 } from '../../../errors';
-import { type ProjectId } from '../../../models';
+import { parseProjectRelPath, type ProjectId } from '../../../models';
 import { type ProjectStore } from '../../../ports';
 import { createDirectoryOps } from './directories';
 
@@ -84,13 +81,12 @@ describe('createDirectory', () => {
   });
 
   it('resolves the parent directory and creates the folder under it', async () => {
-    const parentId = createGitTreeRef({ ref: 'main', path: 'notes' });
     mockCreateDirectory.mockReturnValue(Effect.void);
 
     await Effect.runPromise(
       ops.createDirectory({
         projectId,
-        parentDirectoryId: parentId,
+        parentDirectoryPath: parseProjectRelPath('notes'),
         name: 'sub',
       })
     );
@@ -137,7 +133,7 @@ describe('createDirectory', () => {
 });
 
 describe('deleteDirectory', () => {
-  const directoryId = createGitTreeRef({ ref: 'main', path: 'docs' });
+  const directoryPath = parseProjectRelPath('docs');
 
   it('deletes the tracked documents inside the directory', async () => {
     mockListDirectoryFiles.mockReturnValue(
@@ -153,7 +149,7 @@ describe('deleteDirectory', () => {
     );
     mockDeleteDocuments.mockReturnValue(Effect.void);
 
-    await Effect.runPromise(ops.deleteDirectory({ projectId, directoryId }));
+    await Effect.runPromise(ops.deleteDirectory({ projectId, directoryPath }));
 
     expect(mockDeleteDocuments).toHaveBeenCalledWith({
       documentIds: [
@@ -171,7 +167,7 @@ describe('deleteDirectory', () => {
     mockListDirectoryFiles.mockReturnValue(Effect.succeed([]));
     mockDeleteDirectory.mockReturnValue(Effect.void);
 
-    await Effect.runPromise(ops.deleteDirectory({ projectId, directoryId }));
+    await Effect.runPromise(ops.deleteDirectory({ projectId, directoryPath }));
 
     expect(mockDeleteDirectory).toHaveBeenCalledWith({
       path: `${projectId}/docs`,
@@ -191,7 +187,7 @@ describe('deleteDirectory', () => {
     );
     mockDeleteDirectory.mockReturnValue(Effect.void);
 
-    await Effect.runPromise(ops.deleteDirectory({ projectId, directoryId }));
+    await Effect.runPromise(ops.deleteDirectory({ projectId, directoryPath }));
 
     expect(mockDeleteDirectory).toHaveBeenCalledWith({
       path: `${projectId}/docs`,
@@ -212,7 +208,7 @@ describe('deleteDirectory', () => {
     mockDeleteDirectory.mockReturnValue(Effect.void);
 
     const result = await Effect.runPromise(
-      Effect.either(ops.deleteDirectory({ projectId, directoryId }))
+      Effect.either(ops.deleteDirectory({ projectId, directoryPath }))
     );
 
     expect(result._tag).toBe('Left');
@@ -229,7 +225,7 @@ describe('deleteDirectory', () => {
     );
 
     const result = await Effect.runPromise(
-      Effect.either(ops.deleteDirectory({ projectId, directoryId }))
+      Effect.either(ops.deleteDirectory({ projectId, directoryPath }))
     );
 
     expect(result._tag).toBe('Left');

--- a/src/modules/domain/project/adapters/git/git-project-store/directories.ts
+++ b/src/modules/domain/project/adapters/git/git-project-store/directories.ts
@@ -22,7 +22,6 @@ import {
   type DeleteDirectoryArgs,
   type ProjectStore,
 } from '../../../ports';
-import { resolveAbsolutePath } from './artifacts';
 import { ensureProjectIdIsFsPath } from './project-id';
 
 type DocumentOps = Pick<ProjectStore, 'findDocumentByPath' | 'deleteDocuments'>;
@@ -42,18 +41,17 @@ export const createDirectoryOps = ({
 }): DirectoryOps => {
   const createDirectory = ({
     projectId,
-    parentDirectoryId,
+    parentDirectoryPath,
     name,
   }: CreateDirectoryArgs) =>
     pipe(
       ensureProjectIdIsFsPath(projectId),
       Effect.flatMap((projectDir) =>
         pipe(
-          parentDirectoryId
-            ? resolveAbsolutePath({
-                filesystem,
-                projectDir,
-                artifactId: parentDirectoryId,
+          parentDirectoryPath
+            ? filesystem.getAbsolutePath({
+                path: parentDirectoryPath,
+                dirPath: projectDir,
               })
             : Effect.succeed(projectDir),
           Effect.flatMap((parentAbsolutePath) =>
@@ -73,15 +71,14 @@ export const createDirectoryOps = ({
       })
     );
 
-  const deleteDirectory = ({ projectId, directoryId }: DeleteDirectoryArgs) =>
+  const deleteDirectory = ({ projectId, directoryPath }: DeleteDirectoryArgs) =>
     pipe(
       ensureProjectIdIsFsPath(projectId),
       Effect.flatMap((projectDir) =>
         pipe(
-          resolveAbsolutePath({
-            filesystem,
-            projectDir,
-            artifactId: directoryId,
+          filesystem.getAbsolutePath({
+            path: directoryPath,
+            dirPath: projectDir,
           }),
           Effect.flatMap((absoluteDirPath) =>
             pipe(

--- a/src/modules/domain/project/adapters/git/git-project-store/hierarchy.test.ts
+++ b/src/modules/domain/project/adapters/git/git-project-store/hierarchy.test.ts
@@ -67,7 +67,7 @@ describe('getProjectTree', () => {
     ]);
   });
 
-  it('maps directories to tree-ref nodes with recursively mapped children', async () => {
+  it('maps directories to id-less nodes with recursively mapped children', async () => {
     mockListDirectoryTree.mockReturnValue(
       Effect.succeed([
         file('readme.md', 'readme.md'),
@@ -90,8 +90,6 @@ describe('getProjectTree', () => {
         filesystemType: filesystemItemTypes.FILE,
       },
       {
-        id: '/tree/main/docs',
-        kind: artifactKinds.ASSET,
         path: 'docs',
         filesystemType: filesystemItemTypes.DIRECTORY,
         children: [
@@ -102,8 +100,6 @@ describe('getProjectTree', () => {
             filesystemType: filesystemItemTypes.FILE,
           },
           {
-            id: '/tree/main/docs/2024',
-            kind: artifactKinds.ASSET,
             path: 'docs/2024',
             filesystemType: filesystemItemTypes.DIRECTORY,
             children: [
@@ -129,8 +125,6 @@ describe('getProjectTree', () => {
 
     expect(tree).toEqual([
       {
-        id: '/tree/main/empty',
-        kind: artifactKinds.ASSET,
         path: 'empty',
         filesystemType: filesystemItemTypes.DIRECTORY,
         children: [],
@@ -156,9 +150,11 @@ describe('getProjectTree', () => {
     );
 
     const tree = await Effect.runPromise(store.getProjectTree(PROJECT_PATH));
+    const [fileNode, directoryNode] = tree;
 
-    expect(tree[0].id).toBe('/blob/feature/readme.md');
-    expect(tree[1].id).toBe('/tree/feature/docs');
+    expect(fileNode).toMatchObject({ id: '/blob/feature/readme.md' });
+    // Directories are derived structure, so there is no id to scope to a branch.
+    expect(directoryNode).not.toHaveProperty('id');
   });
 
   it('maps a directory-listing failure to a RepositoryError', async () => {

--- a/src/modules/domain/project/adapters/git/git-project-store/hierarchy.ts
+++ b/src/modules/domain/project/adapters/git/git-project-store/hierarchy.ts
@@ -10,17 +10,15 @@ import {
   type Directory,
   type File,
   type Filesystem,
+  filesystemItemTypes,
   isDirectory,
 } from '../../../../../../modules/infrastructure/filesystem';
-import {
-  createGitBlobRef,
-  createGitTreeRef,
-} from '../../../../../../modules/infrastructure/version-control';
+import { createGitBlobRef } from '../../../../../../modules/infrastructure/version-control';
 import { RepositoryError, ValidationError } from '../../../errors';
 import {
-  type ArtifactTreeNode,
   inferArtifactKindFromExtension,
   parseProjectRelPathEffect,
+  type ProjectTreeNode,
 } from '../../../models';
 import { type ProjectStore } from '../../../ports';
 import { getCurrentBranch } from './branching';
@@ -28,21 +26,19 @@ import { ensureProjectIdIsFsPath } from './project-id';
 
 type HierarchyOps = Pick<ProjectStore, 'getProjectTree'>;
 
-const toArtifactTreeNode =
+const toProjectTreeNode =
   (ref: string) =>
-  (node: Directory | File): Effect.Effect<ArtifactTreeNode, ValidationError> =>
+  (node: Directory | File): Effect.Effect<ProjectTreeNode, ValidationError> =>
     pipe(
       parseProjectRelPathEffect(node.path),
       Effect.flatMap(
-        (path): Effect.Effect<ArtifactTreeNode, ValidationError> =>
+        (path): Effect.Effect<ProjectTreeNode, ValidationError> =>
           isDirectory(node)
             ? pipe(
-                Effect.forEach(node.children ?? [], toArtifactTreeNode(ref)),
+                Effect.forEach(node.children ?? [], toProjectTreeNode(ref)),
                 Effect.map((children) => ({
-                  id: createGitTreeRef({ ref, path }),
                   path,
-                  kind: inferArtifactKindFromExtension(path),
-                  filesystemType: node.type,
+                  filesystemType: filesystemItemTypes.DIRECTORY,
                   children,
                 }))
               )
@@ -50,7 +46,7 @@ const toArtifactTreeNode =
                 id: createGitBlobRef({ ref, path }),
                 path,
                 kind: inferArtifactKindFromExtension(path),
-                filesystemType: node.type,
+                filesystemType: filesystemItemTypes.FILE,
               })
       )
     );
@@ -88,7 +84,7 @@ export const createHierarchyOps = ({
         )
       ),
       Effect.flatMap(({ tree, currentBranch }) =>
-        Effect.forEach(tree, toArtifactTreeNode(currentBranch))
+        Effect.forEach(tree, toProjectTreeNode(currentBranch))
       )
     );
 

--- a/src/modules/domain/project/commands/create-document-in-project.ts
+++ b/src/modules/domain/project/commands/create-document-in-project.ts
@@ -16,21 +16,20 @@ import {
 } from '../../../../modules/infrastructure/filesystem';
 import { type ArtifactId } from '../../../../modules/infrastructure/version-control';
 import { RepositoryError, ValidationError } from '../errors';
-import { type ProjectId } from '../models';
+import { type ProjectId, type ProjectRelPath } from '../models';
 import { type ProjectStore } from '../ports';
 
 export type CreateDocumentInProjectArgs = {
   content: string | null;
   projectId: ProjectId;
   projectDirectory: Directory;
-  parentDirectoryId: ArtifactId | undefined;
+  parentDirectoryPath: ProjectRelPath | undefined;
 };
 
 export type CreateDocumentInProjectDeps = {
   createNewFile: Filesystem['createNewFile'];
   getRelativePath: Filesystem['getRelativePath'];
   getAbsolutePath: Filesystem['getAbsolutePath'];
-  getArtifactMetaDataById: ProjectStore['getArtifactMetaDataById'];
   createDocument: ProjectStore['createDocument'];
 };
 
@@ -44,14 +43,13 @@ export const createDocumentInProject =
     createNewFile,
     getRelativePath,
     getAbsolutePath,
-    getArtifactMetaDataById,
     createDocument,
   }: CreateDocumentInProjectDeps) =>
   ({
     content,
     projectId,
     projectDirectory,
-    parentDirectoryId,
+    parentDirectoryPath,
   }: CreateDocumentInProjectArgs): Effect.Effect<
     Option.Option<CreateDocumentInProjectResult>,
     | FilesystemNotFoundError
@@ -65,18 +63,12 @@ export const createDocumentInProject =
         pipe(
           // Resolve the parent directory to create the file under (the project
           // root when none is given).
-          parentDirectoryId
+          parentDirectoryPath
             ? pipe(
-                getArtifactMetaDataById({
-                  projectId,
-                  artifactId: parentDirectoryId,
+                getAbsolutePath({
+                  path: parentDirectoryPath,
+                  dirPath: projectDirectory.path,
                 }),
-                Effect.flatMap(({ path }) =>
-                  getAbsolutePath({
-                    path,
-                    dirPath: projectDirectory.path,
-                  })
-                ),
                 Effect.map((absolutePath) =>
                   toDirectory({ path: absolutePath })
                 )

--- a/src/modules/domain/project/models/project-artifacts.test.ts
+++ b/src/modules/domain/project/models/project-artifacts.test.ts
@@ -3,14 +3,17 @@ import { describe, expect, it } from 'vitest';
 import { filesystemItemTypes } from '../../../infrastructure/filesystem';
 import { type ArtifactId } from '../../../infrastructure/version-control';
 import {
-  type ArtifactTreeNode,
-  findNodeByPath,
+  findFileNodeByPath,
+  findNodeById,
   inferArtifactKindFromExtension,
   listOpenableArtifacts,
+  type ProjectDirectoryNode,
+  type ProjectFileNode,
+  type ProjectTreeNode,
 } from './project-artifacts';
 import { parseProjectRelPath } from './project-rel-path';
 
-const file = ({ path }: { path: string }): ArtifactTreeNode => ({
+const file = ({ path }: { path: string }): ProjectFileNode => ({
   id: path as ArtifactId,
   path: parseProjectRelPath(path),
   kind: inferArtifactKindFromExtension(path),
@@ -22,11 +25,9 @@ const directory = ({
   children,
 }: {
   path: string;
-  children: ArtifactTreeNode[];
-}): ArtifactTreeNode => ({
-  id: path as ArtifactId,
+  children: ProjectTreeNode[];
+}): ProjectDirectoryNode => ({
   path: parseProjectRelPath(path),
-  kind: inferArtifactKindFromExtension(path),
   filesystemType: filesystemItemTypes.DIRECTORY,
   children,
 });
@@ -95,49 +96,72 @@ describe('listOpenableArtifacts', () => {
   });
 });
 
-describe('findNodeByPath', () => {
-  const tree = [
-    file({ path: 'readme.md' }),
-    directory({
-      path: 'docs',
-      children: [
-        file({ path: 'docs/guide.md' }),
-        directory({
-          path: 'docs/2024',
-          children: [file({ path: 'docs/2024/notes.md' })],
-        }),
-      ],
-    }),
-  ];
+const tree: ProjectTreeNode[] = [
+  file({ path: 'readme.md' }),
+  directory({
+    path: 'docs',
+    children: [
+      file({ path: 'docs/guide.md' }),
+      directory({
+        path: 'docs/2024',
+        children: [file({ path: 'docs/2024/notes.md' })],
+      }),
+    ],
+  }),
+];
 
-  it('finds a node at the root', () => {
+describe('findFileNodeByPath', () => {
+  it('finds a file at the root', () => {
     expect(
-      findNodeByPath({ tree, path: parseProjectRelPath('readme.md') })
+      findFileNodeByPath({ tree, path: parseProjectRelPath('readme.md') })
     ).toBe(tree[0]);
   });
 
-  it('finds a directory node by its own path', () => {
-    expect(findNodeByPath({ tree, path: parseProjectRelPath('docs') })).toBe(
-      tree[1]
-    );
+  it('finds a deeply nested file', () => {
+    expect(
+      findFileNodeByPath({
+        tree,
+        path: parseProjectRelPath('docs/2024/notes.md'),
+      })?.path
+    ).toBe('docs/2024/notes.md');
   });
 
-  it('finds a deeply nested node', () => {
+  // Directories aren't tracked artifacts, so there is nothing to hand back.
+  it('returns null for a directory path', () => {
     expect(
-      findNodeByPath({ tree, path: parseProjectRelPath('docs/2024/notes.md') })
-        ?.path
-    ).toBe('docs/2024/notes.md');
+      findFileNodeByPath({ tree, path: parseProjectRelPath('docs') })
+    ).toBeNull();
   });
 
   it('returns null when the path is absent', () => {
     expect(
-      findNodeByPath({ tree, path: parseProjectRelPath('docs/missing.md') })
+      findFileNodeByPath({ tree, path: parseProjectRelPath('docs/missing.md') })
     ).toBeNull();
   });
 
   it('returns null for an empty tree', () => {
     expect(
-      findNodeByPath({ tree: [], path: parseProjectRelPath('readme.md') })
+      findFileNodeByPath({ tree: [], path: parseProjectRelPath('readme.md') })
     ).toBeNull();
+  });
+});
+
+describe('findNodeById', () => {
+  it('finds a deeply nested file by its artifact id', () => {
+    expect(
+      findNodeById({ tree, id: 'docs/2024/notes.md' as ArtifactId })?.path
+    ).toBe('docs/2024/notes.md');
+  });
+
+  it('returns null when no file carries the id', () => {
+    expect(
+      findNodeById({ tree, id: 'docs/absent.md' as ArtifactId })
+    ).toBeNull();
+  });
+
+  // A directory path can never resolve to an artifact, even though the
+  // explorer keys directory nodes by that same path.
+  it('returns null for a path that belongs to a directory', () => {
+    expect(findNodeById({ tree, id: 'docs' as ArtifactId })).toBeNull();
   });
 });

--- a/src/modules/domain/project/models/project-artifacts.ts
+++ b/src/modules/domain/project/models/project-artifacts.ts
@@ -1,5 +1,4 @@
 import {
-  type FilesystemItemType,
   filesystemItemTypes,
   getExtension,
   removeExtension,
@@ -53,14 +52,31 @@ export const isAssetMetaData = (
   artifact: ArtifactMetaData
 ): artifact is AssetMetaData => artifact.kind === artifactKinds.ASSET;
 
-export type ArtifactTreeNode = ArtifactMetaData & {
-  filesystemType: FilesystemItemType;
-  children?: ArtifactTreeNode[];
+// A file in the project tree. Version control tracks these, so a file has an
+// artifact identity of its own.
+export type ProjectFileNode = ArtifactMetaData & {
+  filesystemType: typeof filesystemItemTypes.FILE;
 };
 
-// The artifact's file name, as it exists on disk.
-export const getArtifactNameWithExtension = (path: ProjectRelPath): string =>
-  removePath(path);
+// A directory is structure derived from the paths of the files under it, not
+// something version control tracks. A directory node carries a path and its
+// contents, but no artifact id or kind.
+export type ProjectDirectoryNode = {
+  path: ProjectRelPath;
+  filesystemType: typeof filesystemItemTypes.DIRECTORY;
+  children: ProjectTreeNode[];
+};
+
+export type ProjectTreeNode = ProjectFileNode | ProjectDirectoryNode;
+
+export const isProjectFileNode = (
+  node: ProjectTreeNode
+): node is ProjectFileNode => node.filesystemType === filesystemItemTypes.FILE;
+
+export const isProjectDirectoryNode = (
+  node: ProjectTreeNode
+): node is ProjectDirectoryNode =>
+  node.filesystemType === filesystemItemTypes.DIRECTORY;
 
 // The artifact's name as the editor presents it — the file name without its
 // extension, since the extension is an implementation detail of the format.
@@ -68,38 +84,46 @@ export const getArtifactName = (path: ProjectRelPath): string =>
   removeExtension(removePath(path));
 
 // Flattens a node tree into a depth-first list of all its nodes.
-const flattenTree = (tree: ArtifactTreeNode[]): ArtifactTreeNode[] =>
-  tree.flatMap((node) => [node, ...flattenTree(node.children ?? [])]);
+const flattenTree = (tree: ProjectTreeNode[]): ProjectTreeNode[] =>
+  tree.flatMap((node) =>
+    isProjectDirectoryNode(node)
+      ? [node, ...flattenTree(node.children)]
+      : [node]
+  );
 
-// Locates a tree node by its project-relative path.
-export const findNodeByPath = ({
+// Locates a file node by its project-relative path. Directories are skipped:
+// they have no artifact identity, so there is nothing for a caller to act on.
+export const findFileNodeByPath = ({
   tree,
   path,
 }: {
-  tree: ArtifactTreeNode[];
+  tree: ProjectTreeNode[];
   path: ProjectRelPath;
-}): ArtifactTreeNode | null =>
-  flattenTree(tree).find((node) => node.path === path) ?? null;
+}): ProjectFileNode | null =>
+  flattenTree(tree)
+    .filter(isProjectFileNode)
+    .find((node) => node.path === path) ?? null;
 
-// Locates a tree node by its artifact id.
+// Locates a file node by its artifact id.
 export const findNodeById = ({
   tree,
   id,
 }: {
-  tree: ArtifactTreeNode[];
+  tree: ProjectTreeNode[];
   id: ArtifactId;
-}): ArtifactTreeNode | null =>
-  flattenTree(tree).find((node) => node.id === id) ?? null;
+}): ProjectFileNode | null =>
+  flattenTree(tree)
+    .filter(isProjectFileNode)
+    .find((node) => node.id === id) ?? null;
 
-// Filters a project artifact tree to the nodes the editor can open, descending
-// into subdirectories and dropping directories and assets with unsupported
-// extensions.
+// Filters a project tree to the files the editor can open, descending into
+// subdirectories and dropping assets with unsupported extensions.
 export const listOpenableArtifacts = (
-  tree: ArtifactTreeNode[]
-): ArtifactTreeNode[] =>
+  tree: ProjectTreeNode[]
+): ProjectFileNode[] =>
   tree.flatMap((node) =>
-    node.filesystemType === filesystemItemTypes.DIRECTORY
-      ? listOpenableArtifacts(node.children ?? [])
+    isProjectDirectoryNode(node)
+      ? listOpenableArtifacts(node.children)
       : node.kind === artifactKinds.RICH_TEXT_DOCUMENT
         ? [node]
         : []

--- a/src/modules/domain/project/ports/project-store.ts
+++ b/src/modules/domain/project/ports/project-store.ts
@@ -26,12 +26,12 @@ import {
 } from '../errors';
 import {
   type ArtifactMetaData,
-  type ArtifactTreeNode,
   type AssetMetaData,
   type DocumentMetaData,
   type Project,
   type ProjectId,
   type ProjectRelPath,
+  type ProjectTreeNode,
   type ReferencedAsset,
   type RemoteProjectInfo,
   type VersionedProject,
@@ -263,13 +263,13 @@ export type CreateDocumentArgs = {
 
 export type CreateDirectoryArgs = {
   projectId: ProjectId;
-  parentDirectoryId?: ArtifactId;
+  parentDirectoryPath?: ProjectRelPath;
   name: string;
 };
 
 export type DeleteDirectoryArgs = {
   projectId: ProjectId;
-  directoryId: ArtifactId;
+  directoryPath: ProjectRelPath;
 };
 
 export type GetArtifactMetaDataByIdArgs = {
@@ -379,7 +379,7 @@ export type ProjectStore = {
   getProjectTree: (
     id: ProjectId
   ) => Effect.Effect<
-    ArtifactTreeNode[],
+    ProjectTreeNode[],
     ValidationError | RepositoryError | NotFoundError | MigrationError,
     never
   >;

--- a/src/renderer/src/app-state/current-project/current-artifact/artifact-metadata.ts
+++ b/src/renderer/src/app-state/current-project/current-artifact/artifact-metadata.ts
@@ -3,10 +3,10 @@ import { useContext, useEffect, useMemo, useState } from 'react';
 
 import {
   type ArtifactMetaData,
-  type ArtifactTreeNode,
   findNodeById,
   type ProjectId,
   type ProjectStore,
+  type ProjectTreeNode,
 } from '../../../../../modules/domain/project';
 import { type ArtifactId } from '../../../../../modules/infrastructure/version-control';
 import { ProjectContext } from '../context';
@@ -36,16 +36,13 @@ export const useArtifactMetaDataFromTree = ({
   tree,
   artifactId,
 }: {
-  tree: ArtifactTreeNode[];
+  tree: ProjectTreeNode[];
   artifactId: ArtifactId | null;
 }): ArtifactMetaData | null =>
-  useMemo(() => {
-    if (!artifactId) return null;
-
-    const node = findNodeById({ tree, id: artifactId });
-
-    return node ? { id: node.id, path: node.path, kind: node.kind } : null;
-  }, [tree, artifactId]);
+  useMemo(
+    () => (artifactId ? findNodeById({ tree, id: artifactId }) : null),
+    [tree, artifactId]
+  );
 
 export const useResolveArtifactMetaData = ({
   projectId,

--- a/src/renderer/src/app-state/current-project/directories.ts
+++ b/src/renderer/src/app-state/current-project/directories.ts
@@ -3,7 +3,6 @@ import { useCallback, useContext, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import {
-  findNodeByPath,
   isPathInsideDirectory,
   parseProjectRelPath,
   type ProjectRelPath,
@@ -17,7 +16,7 @@ import { type PendingNewDirectory, type ProjectContextType } from './types';
 
 type DirectoryDeps = Pick<
   ProjectContextType,
-  'projectId' | 'projectStore' | 'directoryTree' | 'refreshDirectoryTree'
+  'projectId' | 'projectStore' | 'refreshDirectoryTree'
 > & {
   currentArtifactPath: ProjectRelPath | null;
 };
@@ -38,7 +37,6 @@ type DirectoryOps = Pick<
 export const useDirectoryOps = ({
   projectId,
   projectStore,
-  directoryTree,
   refreshDirectoryTree,
   currentArtifactPath,
 }: DirectoryDeps): DirectoryOps => {
@@ -55,27 +53,18 @@ export const useDirectoryOps = ({
     async (name: string) => {
       if (!projectStore || !projectId || !pendingNewDirectory) return;
 
-      const parentDirectoryId = pendingNewDirectory.parentPath
-        ? (findNodeByPath({
-            tree: directoryTree,
-            path: parseProjectRelPath(pendingNewDirectory.parentPath),
-          })?.id ?? undefined)
+      const parentDirectoryPath = pendingNewDirectory.parentPath
+        ? parseProjectRelPath(pendingNewDirectory.parentPath)
         : undefined;
 
       await Effect.runPromise(
-        projectStore.createDirectory({ projectId, parentDirectoryId, name })
+        projectStore.createDirectory({ projectId, parentDirectoryPath, name })
       );
 
       await refreshDirectoryTree();
       setPendingNewDirectory(null);
     },
-    [
-      projectStore,
-      projectId,
-      directoryTree,
-      pendingNewDirectory,
-      refreshDirectoryTree,
-    ]
+    [projectStore, projectId, pendingNewDirectory, refreshDirectoryTree]
   );
 
   const startCreateDirectory = useCallback(
@@ -95,18 +84,11 @@ export const useDirectoryOps = ({
         );
       }
 
-      const directoryId = findNodeByPath({
-        tree: directoryTree,
-        path: parseProjectRelPath(relativePath),
-      })?.id;
-      if (!directoryId) {
-        setDirectoryToDelete(null);
-        return;
-      }
+      const directoryPath = parseProjectRelPath(relativePath);
 
       try {
         await Effect.runPromise(
-          projectStore.deleteDirectory({ projectId, directoryId })
+          projectStore.deleteDirectory({ projectId, directoryPath })
         );
 
         await refreshDirectoryTree();
@@ -115,7 +97,7 @@ export const useDirectoryOps = ({
         if (
           currentArtifactPath &&
           isPathInsideDirectory({
-            directoryPath: parseProjectRelPath(relativePath),
+            directoryPath,
             filePath: currentArtifactPath,
           })
         ) {
@@ -138,7 +120,6 @@ export const useDirectoryOps = ({
     [
       projectStore,
       projectId,
-      directoryTree,
       currentArtifactPath,
       navigate,
       refreshDirectoryTree,

--- a/src/renderer/src/app-state/current-project/documents.ts
+++ b/src/renderer/src/app-state/current-project/documents.ts
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router';
 
 import {
   createDocumentInProject,
-  findNodeByPath,
+  findFileNodeByPath,
   parseProjectRelPath,
   type ProjectId,
   type ProjectRelPath,
@@ -64,11 +64,8 @@ export const useDocumentOps = ({
         );
       }
 
-      const parentDirectoryId = args?.parentPath
-        ? (findNodeByPath({
-            tree: directoryTree,
-            path: parseProjectRelPath(args.parentPath),
-          })?.id ?? undefined)
+      const parentDirectoryPath = args?.parentPath
+        ? parseProjectRelPath(args.parentPath)
         : undefined;
 
       const result = await Effect.runPromise(
@@ -77,12 +74,11 @@ export const useDocumentOps = ({
             createNewFile: filesystem.createNewFile,
             getRelativePath: filesystem.getRelativePath,
             getAbsolutePath: filesystem.getAbsolutePath,
-            getArtifactMetaDataById: projectStore.getArtifactMetaDataById,
             createDocument: projectStore.createDocument,
           })({
             projectId,
             projectDirectory: directory,
-            parentDirectoryId,
+            parentDirectoryPath,
             content: null,
           }),
           Effect.map(Option.getOrNull)
@@ -102,14 +98,7 @@ export const useDocumentOps = ({
         path: result.filePath,
       };
     },
-    [
-      projectStore,
-      projectId,
-      directory,
-      filesystem,
-      directoryTree,
-      refreshDirectoryTree,
-    ]
+    [projectStore, projectId, directory, filesystem, refreshDirectoryTree]
   );
 
   const handleFindDocumentInProject = async (args: {
@@ -140,7 +129,7 @@ export const useDocumentOps = ({
         );
       }
 
-      const documentId = findNodeByPath({
+      const documentId = findFileNodeByPath({
         tree: directoryTree,
         path: parseProjectRelPath(relativePath),
       })?.id;

--- a/src/renderer/src/app-state/current-project/hierarchy.ts
+++ b/src/renderer/src/app-state/current-project/hierarchy.ts
@@ -1,7 +1,7 @@
 import * as Effect from 'effect/Effect';
 import { useCallback, useEffect, useState } from 'react';
 
-import { type ArtifactTreeNode } from '../../../../modules/domain/project';
+import { type ProjectTreeNode } from '../../../../modules/domain/project';
 import { type ProjectContextType } from './types';
 
 type HierarchyDeps = Pick<
@@ -23,7 +23,7 @@ export const useHierarchyOps = ({
   currentBranch,
   pulledUpstreamChanges,
 }: HierarchyDeps): HierarchyOps => {
-  const [directoryTree, setDirectoryTree] = useState<ArtifactTreeNode[]>([]);
+  const [directoryTree, setDirectoryTree] = useState<ProjectTreeNode[]>([]);
 
   const refreshDirectoryTree = useCallback(async () => {
     if (

--- a/src/renderer/src/app-state/current-project/provider.tsx
+++ b/src/renderer/src/app-state/current-project/provider.tsx
@@ -85,7 +85,6 @@ export const ProjectProvider = ({
   const directoryOps = useDirectoryOps({
     projectId,
     projectStore,
-    directoryTree,
     refreshDirectoryTree,
     currentArtifactPath,
   });

--- a/src/renderer/src/app-state/current-project/types.ts
+++ b/src/renderer/src/app-state/current-project/types.ts
@@ -1,8 +1,8 @@
 import {
   type ArtifactMetaData,
-  type ArtifactTreeNode,
   type ProjectId,
   type ProjectStore,
+  type ProjectTreeNode,
   type RemoteProjectInfo,
 } from '../../../../modules/domain/project';
 import { type ResolvedDocument } from '../../../../modules/domain/rich-text';
@@ -40,7 +40,7 @@ export type ProjectContextType = {
   projectStore: ProjectStore | null;
   currentArtifact: ArtifactMetaData | null;
   resolvingCurrentArtifact: boolean;
-  directoryTree: ArtifactTreeNode[];
+  directoryTree: ProjectTreeNode[];
   refreshDirectoryTree: () => Promise<void>;
   openDirectory: (cloneUrl?: string) => Promise<Directory>;
   requestPermissionForSelectedDirectory: () => Promise<void>;

--- a/src/renderer/src/pages/project/shared/explorer-tree-views/explorer-tree.test.ts
+++ b/src/renderer/src/pages/project/shared/explorer-tree-views/explorer-tree.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  type ArtifactTreeNode,
   inferArtifactKindFromExtension,
   parseProjectRelPath,
+  type ProjectDirectoryNode,
+  type ProjectFileNode,
+  type ProjectTreeNode,
 } from '../../../../../../modules/domain/project';
 import { filesystemItemTypes } from '../../../../../../modules/infrastructure/filesystem';
 import { type ArtifactId } from '../../../../../../modules/infrastructure/version-control';
@@ -15,8 +17,8 @@ import { type ExplorerTreeNode, NEW_DIRECTORY_NODE_ID } from './tree/types';
 
 const basename = (path: string) => path.split('/').pop() ?? path;
 
-// ArtifactTreeNode fixtures (input to getExplorerTreeInProject)
-const artifactFile = (path: string): ArtifactTreeNode => ({
+// ProjectTreeNode fixtures (input to getExplorerTreeInProject)
+const artifactFile = (path: string): ProjectFileNode => ({
   id: path as ArtifactId,
   path: parseProjectRelPath(path),
   kind: inferArtifactKindFromExtension(path),
@@ -28,11 +30,9 @@ const artifactDir = ({
   children,
 }: {
   path: string;
-  children: ArtifactTreeNode[];
-}): ArtifactTreeNode => ({
-  id: path as ArtifactId,
+  children: ProjectTreeNode[];
+}): ProjectDirectoryNode => ({
   path: parseProjectRelPath(path),
-  kind: inferArtifactKindFromExtension(path),
   filesystemType: filesystemItemTypes.DIRECTORY,
   children,
 });

--- a/src/renderer/src/pages/project/shared/explorer-tree-views/explorer-tree.ts
+++ b/src/renderer/src/pages/project/shared/explorer-tree-views/explorer-tree.ts
@@ -1,8 +1,11 @@
 import {
-  type ArtifactTreeNode,
-  getArtifactNameWithExtension,
+  isProjectDirectoryNode,
+  type ProjectTreeNode,
 } from '../../../../../../modules/domain/project';
-import { filesystemItemTypes } from '../../../../../../modules/infrastructure/filesystem';
+import {
+  filesystemItemTypes,
+  removePath,
+} from '../../../../../../modules/infrastructure/filesystem';
 import { type ExplorerTreeNode, NEW_DIRECTORY_NODE_ID } from './tree/types';
 
 export const injectPendingDirectoryNode = (
@@ -38,19 +41,19 @@ export const injectPendingDirectoryNode = (
 };
 
 export const getExplorerTreeInProject = (
-  directoryTree: ArtifactTreeNode[]
+  directoryTree: ProjectTreeNode[]
 ): ExplorerTreeNode[] => {
-  const toExplorerNode = (node: ArtifactTreeNode): ExplorerTreeNode =>
-    node.filesystemType === filesystemItemTypes.DIRECTORY
+  const toExplorerNode = (node: ProjectTreeNode): ExplorerTreeNode =>
+    isProjectDirectoryNode(node)
       ? {
           id: node.path,
-          name: getArtifactNameWithExtension(node.path),
+          name: removePath(node.path),
           type: filesystemItemTypes.DIRECTORY,
-          children: node.children?.map(toExplorerNode),
+          children: node.children.map(toExplorerNode),
         }
       : {
           id: node.path,
-          name: getArtifactNameWithExtension(node.path),
+          name: removePath(node.path),
           type: filesystemItemTypes.FILE,
         };
 


### PR DESCRIPTION
## Description

Updates the project directories model, so that they are treated as merely structural components and not versioned artifacts. Thus directories no longer take artifact IDs and types, just participate in the project filesystem tree.

## Related Issue

Closes #398 