### PR TITLE
Fix inaccurate open-doc error notification on deleted document in project history

### DIFF
--- a/e2e/projects/history.spec.ts
+++ b/e2e/projects/history.spec.ts
@@ -205,6 +205,9 @@ test.describe('project history', () => {
     await expect(window.locator('.ProseMirror')).toContainText('preserved', {
       timeout: 1_000,
     });
+
+    // Viewing a deleted document in history is handled, not an error
+    await expect(window.getByTestId('error-notification')).toHaveCount(0);
   });
 
   test('diff annotations appear in project history', async ({

--- a/src/renderer/src/app-state/current-document/use-current-document-id.ts
+++ b/src/renderer/src/app-state/current-document/use-current-document-id.ts
@@ -1,13 +1,19 @@
 import { useContext } from 'react';
+import { useMatch } from 'react-router';
 
 import { artifactKinds } from '../../../../modules/domain/project';
 import { ProjectContext } from '../current-project/context';
 
 // The current artifact's id, or null when the open artifact isn't a document.
+// For routes outside the artifact subtree we also consider the current document null.
 export const useCurrentDocumentId = () => {
   const { currentArtifact } = useContext(ProjectContext);
+  const artifactRouteMatch = useMatch(
+    '/projects/:projectId/artifacts/:artifactId/*'
+  );
 
-  return currentArtifact?.kind === artifactKinds.RICH_TEXT_DOCUMENT
+  return artifactRouteMatch &&
+    currentArtifact?.kind === artifactKinds.RICH_TEXT_DOCUMENT
     ? currentArtifact.id
     : null;
 };

--- a/src/renderer/src/components/notifications/GenericNotifications.tsx
+++ b/src/renderer/src/components/notifications/GenericNotifications.tsx
@@ -58,6 +58,7 @@ const ErrorNotification = ({
     iconClasses="text-red-400"
     title={notification.title}
     message={notification.message}
+    testId="error-notification"
   />
 );
 

--- a/src/renderer/src/components/notifications/SimpleNotification.tsx
+++ b/src/renderer/src/components/notifications/SimpleNotification.tsx
@@ -11,6 +11,7 @@ export type SimpleNotificationProps = {
   iconClasses?: string;
   message?: string;
   messageElement?: React.ReactNode;
+  testId?: string;
 };
 
 export const SimpleNotification = ({
@@ -21,12 +22,16 @@ export const SimpleNotification = ({
   iconClasses,
   message,
   messageElement,
+  testId,
 }: SimpleNotificationProps) => {
   const Icon = icon ?? InfoIcon;
 
   return (
     <Transition show={show}>
-      <div className="pointer-events-auto w-full max-w-sm bg-white shadow-lg outline outline-1 outline-black/5 transition data-[closed]:data-[enter]:translate-y-2 data-[enter]:transform data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-100 data-[enter]:ease-out data-[leave]:ease-in data-[closed]:data-[enter]:sm:translate-x-2 data-[closed]:data-[enter]:sm:translate-y-0 dark:bg-gray-800 dark:-outline-offset-1 dark:outline-white/10">
+      <div
+        data-testid={testId}
+        className="pointer-events-auto w-full max-w-sm bg-white shadow-lg outline outline-1 outline-black/5 transition data-[closed]:data-[enter]:translate-y-2 data-[enter]:transform data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-100 data-[enter]:ease-out data-[leave]:ease-in data-[closed]:data-[enter]:sm:translate-x-2 data-[closed]:data-[enter]:sm:translate-y-0 dark:bg-gray-800 dark:-outline-offset-1 dark:outline-white/10"
+      >
         <div className="p-4">
           <div className="flex items-start">
             <div className="shrink-0">

--- a/src/renderer/src/pages/project/shared/command-palette/index.tsx
+++ b/src/renderer/src/pages/project/shared/command-palette/index.tsx
@@ -34,9 +34,8 @@ export const ProjectCommandPalette = ({
   const { isOpen: isCommandPaletteOpen, closeCommandPalette } = useContext(
     CommandPaletteContext
   );
-  const { canCommit, onOpenDiscardChangesDialog } = useContext(
-    CurrentDocumentContext
-  );
+  const { canCommit, onOpenDiscardChangesDialog, versionedDocumentId } =
+    useContext(CurrentDocumentContext);
   const { openCommitModal } = useContext(CommitModalContext);
   const { checkForUpdate } = useContext(ElectronContext);
   const { directoryTree, currentArtifact } = useContext(ProjectContext);
@@ -143,7 +142,7 @@ export const ProjectCommandPalette = ({
       onClose={closeCommandPalette}
       documentsGroupTitle="Project documents"
       contextualSection={
-        currentDocumentName
+        versionedDocumentId && currentDocumentName
           ? {
               groupTitle: `Current document: ${currentDocumentName}`,
               actions: documentActions,


### PR DESCRIPTION
## Description

Fixes an issue where visiting a deleted document in project history was triggering an open-document error notification. The current document is now considered `null` unless we are in the artifacts route tree.

## Related Issue

Fixes #400 

