### PR TITLE
Commit an initial snapshot of a folder if there is no existing repo

### DIFF
--- a/e2e/branching/switching.spec.ts
+++ b/e2e/branching/switching.spec.ts
@@ -28,7 +28,6 @@ test.describe('branch switching', () => {
     });
     await openDocument({ window, relativePath: 'hello.md' });
     await expect(editor(window)).toContainText('This is a test document.');
-    await commitChanges({ window, message: 'base commit' });
 
     await createAndSwitchToBranch({ window, branchName: 'experiment' });
     await typeInParagraphAndWaitForDebounce({ window, text: ' on experiment' });
@@ -55,7 +54,6 @@ test.describe('branch switching', () => {
       folderPath: testProjectDir,
     });
     await openDocument({ window, relativePath: 'hello.md' });
-    await commitChanges({ window, message: 'base commit' });
 
     await createAndSwitchToBranch({ window, branchName: 'experiment' });
 

--- a/e2e/documents/commit-workflow.spec.ts
+++ b/e2e/documents/commit-workflow.spec.ts
@@ -30,8 +30,9 @@ test('commit flow: edit → commit → one commit in history', async ({
   await typeInEditorAndWaitForDebounce({ window, text: ' first edit' });
   await commitChanges({ window, message: 'first commit' });
 
+  // The new commit sits on top of the initial snapshot taken when the folder was opened.
   const commits = window.getByTestId('history-commit');
-  await expect(commits).toHaveCount(1);
+  await expect(commits).toHaveCount(2);
   await expect(commits.first()).toContainText('first commit');
 });
 
@@ -55,7 +56,7 @@ test('view uncommitted changes and show diff', async ({
   await expect(window.getByTestId('document-history')).toBeVisible();
 });
 
-test('commit from history view → two commits in history', async ({
+test('commit from history view → two new commits in history', async ({
   electronApp,
   window,
   testProjectDir,
@@ -70,8 +71,9 @@ test('commit from history view → two commits in history', async ({
   await selectUncommittedChanges({ window });
   await commitChanges({ window, message: 'second commit' });
 
+  // The new commits sit on top of the initial snapshot taken when the folder was opened.
   const commits = window.getByTestId('history-commit');
-  await expect(commits).toHaveCount(2);
+  await expect(commits).toHaveCount(3);
 });
 
 test('first commit shows its content', async ({
@@ -95,7 +97,7 @@ test('first commit shows its content', async ({
   });
 });
 
-test('second commit shows diff controls but initial commit does not', async ({
+test('later commits show diff controls but the initial snapshot does not', async ({
   electronApp,
   window,
   testProjectDir,
@@ -106,16 +108,13 @@ test('second commit shows diff controls but initial commit does not', async ({
   await typeInEditorAndWaitForDebounce({ window, text: ' first' });
   await commitChanges({ window, message: 'first commit' });
 
-  await typeInEditorAndWaitForDebounce({ window, text: ' second' });
-  await commitChanges({ window, message: 'second commit' });
-
-  // The latest (second) commit should show the diff controls
-  await selectFirstCommit({ window, commitMessage: 'second commit' });
+  // Any commit with a predecessor should show the diff controls
+  await selectFirstCommit({ window, commitMessage: 'first commit' });
   await expect(window.locator('.ProseMirror')).toBeVisible({ timeout: 1_000 });
   await expect(window.getByLabel(/show diff with/i)).toBeVisible();
 
-  // The initial (first) commit should hide the diff controls
-  await selectFirstCommit({ window, commitMessage: 'first commit' });
+  // The initial snapshot has nothing to diff against, so it hides them
+  await selectFirstCommit({ window, commitMessage: 'Set up versioning' });
   await expect(window.locator('.ProseMirror')).toBeVisible({ timeout: 1_000 });
   await expect(window.getByLabel(/show diff with/i)).toBeHidden();
 });
@@ -159,10 +158,12 @@ test('commits are ordered most recent first', async ({
   await typeInEditorAndWaitForDebounce({ window, text: ' beta' });
   await commitChanges({ window, message: 'beta commit' });
 
+  // The new commits sit on top of the initial snapshot taken when the folder was opened.
   const commits = window.getByTestId('history-commit');
-  await expect(commits).toHaveCount(2);
+  await expect(commits).toHaveCount(3);
   await expect(commits.first()).toContainText('beta commit');
-  await expect(commits.last()).toContainText('alpha commit');
+  await expect(commits.nth(1)).toContainText('alpha commit');
+  await expect(commits.last()).toContainText('Set up versioning');
 });
 
 test('diff annotations appear on a committed change', async ({
@@ -291,7 +292,8 @@ test('restore commit reverts content and creates a new commit', async ({
 
   // A new "Restore" commit should appear
   const commits = window.getByTestId('history-commit');
-  await expect(commits).toHaveCount(3);
+  // There is also an initial snapshot commit taken when the folder was opened.
+  await expect(commits).toHaveCount(4);
   await expect(commits.first()).toContainText('Restore');
 
   // Return to editor and verify content matches the original

--- a/e2e/merge-conflicts/preserves-uninvolved-files.spec.ts
+++ b/e2e/merge-conflicts/preserves-uninvolved-files.spec.ts
@@ -4,7 +4,6 @@ import path from 'path';
 
 import { expect, test } from '../shared/fixtures';
 import {
-  commitAllProjectChanges,
   commitChanges,
   createAndSwitchToBranch,
   mergeToMainBranch,
@@ -68,10 +67,6 @@ const mergeWithConflict = async ({
 }): Promise<void> => {
   await openDocument({ window, relativePath: CONFLICTING_DOC });
   await expect(editor(window)).toContainText('Lorem ipsum dolor');
-
-  // Commit the whole project, so the uninvolved files are tracked rather than
-  // just the document being edited.
-  await commitAllProjectChanges({ window, message: 'base commit' });
 
   await createAndSwitchToBranch({ window, branchName: 'experiment' });
   await expect(editor(window)).toContainText('Lorem ipsum dolor');

--- a/e2e/merge-conflicts/resolution.spec.ts
+++ b/e2e/merge-conflicts/resolution.spec.ts
@@ -39,7 +39,6 @@ const createMergeConflictForDocument = async ({
   await openDocument({ window, relativePath });
 
   await expect(editor(window)).toContainText('Lorem ipsum dolor');
-  await commitChanges({ window, message: 'base commit' });
 
   await createAndSwitchToBranch({ window, branchName: 'experiment' });
   await expect(editor(window)).toContainText('Lorem ipsum dolor');

--- a/e2e/projects/commit-to-project.spec.ts
+++ b/e2e/projects/commit-to-project.spec.ts
@@ -42,15 +42,16 @@ test.describe('commit to project (multi-doc)', () => {
       message: 'project-scoped commit',
     });
 
-    // The history sidebar in the document view should show the new commit.
+    // The history sidebar in the document view should show the new commit on
+    // top of the initial snapshot taken when the folder was opened.
     const docCommits = window.getByTestId('history-commit');
-    await expect(docCommits).toHaveCount(1);
+    await expect(docCommits).toHaveCount(2);
     await expect(docCommits.first()).toContainText('project-scoped commit');
 
-    // Project history should contain a single commit with both documents.
+    // Project history should contain a single new commit with both documents.
     await navigateToProjectHistory({ window });
     const projectCommits = window.getByTestId('project-commit-row');
-    await expect(projectCommits).toHaveCount(1);
+    await expect(projectCommits).toHaveCount(2);
     await expect(projectCommits.first()).toContainText('project-scoped commit');
 
     await toggleProjectCommit({
@@ -87,11 +88,11 @@ test.describe('commit to project (multi-doc)', () => {
       message: 'project commit from history view',
     });
 
-    // Project history should contain a single commit with both documents,
+    // Project history should contain a single new commit with both documents,
     // matching the outcome of the same flow fired from the editor view.
     await navigateToProjectHistory({ window });
     const projectCommits = window.getByTestId('project-commit-row');
-    await expect(projectCommits).toHaveCount(1);
+    await expect(projectCommits).toHaveCount(2);
     await expect(projectCommits.first()).toContainText(
       'project commit from history view'
     );

--- a/e2e/projects/history.spec.ts
+++ b/e2e/projects/history.spec.ts
@@ -34,10 +34,13 @@ test.describe('project history', () => {
 
     await navigateToProjectHistory({ window });
 
+    // Three rows: the two commits made here, on top of the initial snapshot
+    // taken when the folder was opened.
     const commitRows = window.getByTestId('project-commit-row');
-    await expect(commitRows).toHaveCount(2);
+    await expect(commitRows).toHaveCount(3);
     await expect(commitRows.first()).toContainText('second commit');
-    await expect(commitRows.last()).toContainText('first commit');
+    await expect(commitRows.nth(1)).toContainText('first commit');
+    await expect(commitRows.last()).toContainText('Set up versioning');
   });
 
   test('expand a commit to see changed documents', async ({

--- a/e2e/projects/history.spec.ts
+++ b/e2e/projects/history.spec.ts
@@ -4,6 +4,7 @@ import {
   confirmDeletion,
   deleteFileFromContextMenu,
   enableShowDiff,
+  expectProjectCommits,
   navigateToProjectHistory,
   openHelloMd,
   openProjectFolder,
@@ -34,13 +35,12 @@ test.describe('project history', () => {
 
     await navigateToProjectHistory({ window });
 
-    // Three rows: the two commits made here, on top of the initial snapshot
-    // taken when the folder was opened.
-    const commitRows = window.getByTestId('project-commit-row');
-    await expect(commitRows).toHaveCount(3);
-    await expect(commitRows.first()).toContainText('second commit');
-    await expect(commitRows.nth(1)).toContainText('first commit');
-    await expect(commitRows.last()).toContainText('Set up versioning');
+    // The two commits made here, on top of the initial snapshot taken when the
+    // folder was opened.
+    await expectProjectCommits({
+      window,
+      messages: ['second commit', 'first commit', 'Set up versioning'],
+    });
   });
 
   test('expand a commit to see changed documents', async ({

--- a/e2e/projects/opening.spec.ts
+++ b/e2e/projects/opening.spec.ts
@@ -2,13 +2,41 @@ import fs from 'fs';
 import path from 'path';
 
 import { expect, test } from '../shared/fixtures';
+import {
+  commitMessages,
+  hasCleanWorkingTree,
+  initRepositoryWithCommit,
+  lastCommitAuthor,
+  trackedFiles,
+} from '../shared/git';
 import { openDocument, openProjectFolder } from '../shared/helpers';
 
 const fileExplorer = (window: Parameters<typeof openDocument>[0]['window']) =>
   window.getByTestId('file-explorer');
 
 test.describe('project opening', () => {
-  test('git auto-init: opening a plain folder creates a .git directory', async ({
+  test('.git missing, folder empty: commits just the generated .gitignore', async ({
+    electronApp,
+    window,
+    emptyProjectDir,
+  }) => {
+    await openProjectFolder({
+      electronApp,
+      window,
+      folderPath: emptyProjectDir,
+    });
+
+    await expect
+      .poll(() => commitMessages({ repoDir: emptyProjectDir }), {
+        timeout: 5_000,
+      })
+      .toEqual(['Set up versioning']);
+
+    expect(trackedFiles({ repoDir: emptyProjectDir })).toEqual(['.gitignore']);
+    expect(hasCleanWorkingTree({ repoDir: emptyProjectDir })).toBe(true);
+  });
+
+  test('.git missing, .gitignore missing: initialises and commits the folder as found', async ({
     electronApp,
     window,
     testProjectDir,
@@ -22,10 +50,82 @@ test.describe('project opening', () => {
       folderPath: testProjectDir,
     });
 
-    // Wait for git to initialise the repo
-    await window.waitForTimeout(500);
+    // Reading the log at all proves the repo was initialised.
+    await expect
+      .poll(() => commitMessages({ repoDir: testProjectDir }), {
+        timeout: 5_000,
+      })
+      .toEqual(['Set up versioning']);
 
-    expect(fs.existsSync(path.join(testProjectDir, '.git'))).toBe(true);
+    // Everything the folder came with, plus the generated gitignore, is in the
+    // snapshot — nothing is left dangling as an uncommitted change.
+    expect(trackedFiles({ repoDir: testProjectDir })).toEqual([
+      '.gitignore',
+      'config.json',
+      'hello.md',
+      'world.md',
+    ]);
+    expect(hasCleanWorkingTree({ repoDir: testProjectDir })).toBe(true);
+    expect(lastCommitAuthor({ repoDir: testProjectDir })).toBe(
+      'v2 Bot <bot@v2editor.com>'
+    );
+  });
+
+  test('.git missing, .gitignore present: keeps it and honours its rules', async ({
+    electronApp,
+    window,
+    testProjectDir,
+  }) => {
+    const existingGitignore = '# mine\nconfig.json\n';
+    fs.writeFileSync(
+      path.join(testProjectDir, '.gitignore'),
+      existingGitignore
+    );
+
+    await openProjectFolder({
+      electronApp,
+      window,
+      folderPath: testProjectDir,
+    });
+
+    await expect
+      .poll(() => commitMessages({ repoDir: testProjectDir }), {
+        timeout: 5_000,
+      })
+      .toEqual(['Set up versioning']);
+
+    expect(
+      fs.readFileSync(path.join(testProjectDir, '.gitignore'), 'utf8')
+    ).toBe(existingGitignore);
+    // Their rules govern the snapshot: config.json is excluded by them.
+    expect(trackedFiles({ repoDir: testProjectDir })).toEqual([
+      '.gitignore',
+      'hello.md',
+      'world.md',
+    ]);
+  });
+
+  test('.git present: nothing is created', async ({
+    electronApp,
+    window,
+    testProjectDir,
+  }) => {
+    initRepositoryWithCommit({
+      repoDir: testProjectDir,
+      message: 'their own commit',
+    });
+
+    await openProjectFolder({
+      electronApp,
+      window,
+      folderPath: testProjectDir,
+    });
+    await expect(fileExplorer(window).getByText('hello.md')).toBeVisible();
+
+    expect(commitMessages({ repoDir: testProjectDir })).toEqual([
+      'their own commit',
+    ]);
+    expect(fs.existsSync(path.join(testProjectDir, '.gitignore'))).toBe(false);
   });
 
   test('reopens the last opened project after a reload', async ({

--- a/e2e/projects/opening.spec.ts
+++ b/e2e/projects/opening.spec.ts
@@ -3,16 +3,21 @@ import path from 'path';
 
 import { expect, test } from '../shared/fixtures';
 import {
-  commitMessages,
   hasCleanWorkingTree,
   initRepositoryWithCommit,
   lastCommitAuthor,
-  trackedFiles,
 } from '../shared/git';
-import { openDocument, openProjectFolder } from '../shared/helpers';
+import {
+  expectCommitChanges,
+  expectProjectCommits,
+  navigateToProjectHistory,
+  openDocument,
+  openProjectFolder,
+} from '../shared/helpers';
 
-const fileExplorer = (window: Parameters<typeof openDocument>[0]['window']) =>
-  window.getByTestId('file-explorer');
+type Window = Parameters<typeof openDocument>[0]['window'];
+
+const fileExplorer = (window: Window) => window.getByTestId('file-explorer');
 
 test.describe('project opening', () => {
   test('.git missing, folder empty: commits just the generated .gitignore', async ({
@@ -25,14 +30,16 @@ test.describe('project opening', () => {
       window,
       folderPath: emptyProjectDir,
     });
+    // The history view renders only once the project is open, so asserting the
+    // snapshot here is also what makes the git reads below race-free.
+    await navigateToProjectHistory({ window });
+    await expectProjectCommits({ window, messages: ['Set up versioning'] });
+    await expectCommitChanges({
+      window,
+      commitMessage: 'Set up versioning',
+      added: ['.gitignore'],
+    });
 
-    await expect
-      .poll(() => commitMessages({ repoDir: emptyProjectDir }), {
-        timeout: 5_000,
-      })
-      .toEqual(['Set up versioning']);
-
-    expect(trackedFiles({ repoDir: emptyProjectDir })).toEqual(['.gitignore']);
     expect(hasCleanWorkingTree({ repoDir: emptyProjectDir })).toBe(true);
   });
 
@@ -49,22 +56,15 @@ test.describe('project opening', () => {
       window,
       folderPath: testProjectDir,
     });
+    await navigateToProjectHistory({ window });
+    await expectProjectCommits({ window, messages: ['Set up versioning'] });
+    await expectCommitChanges({
+      window,
+      commitMessage: 'Set up versioning',
+      added: ['.gitignore', 'config.json', 'hello.md', 'world.md'],
+    });
 
-    // Reading the log at all proves the repo was initialised.
-    await expect
-      .poll(() => commitMessages({ repoDir: testProjectDir }), {
-        timeout: 5_000,
-      })
-      .toEqual(['Set up versioning']);
-
-    // Everything the folder came with, plus the generated gitignore, is in the
-    // snapshot — nothing is left dangling as an uncommitted change.
-    expect(trackedFiles({ repoDir: testProjectDir })).toEqual([
-      '.gitignore',
-      'config.json',
-      'hello.md',
-      'world.md',
-    ]);
+    // Nothing the folder came with is left dangling as an uncommitted change.
     expect(hasCleanWorkingTree({ repoDir: testProjectDir })).toBe(true);
     expect(lastCommitAuthor({ repoDir: testProjectDir })).toBe(
       'v2 Bot <bot@v2editor.com>'
@@ -87,22 +87,18 @@ test.describe('project opening', () => {
       window,
       folderPath: testProjectDir,
     });
-
-    await expect
-      .poll(() => commitMessages({ repoDir: testProjectDir }), {
-        timeout: 5_000,
-      })
-      .toEqual(['Set up versioning']);
+    await navigateToProjectHistory({ window });
+    await expectProjectCommits({ window, messages: ['Set up versioning'] });
+    // config.json is excluded by their rules, so it never enters the snapshot.
+    await expectCommitChanges({
+      window,
+      commitMessage: 'Set up versioning',
+      added: ['.gitignore', 'hello.md', 'world.md'],
+    });
 
     expect(
       fs.readFileSync(path.join(testProjectDir, '.gitignore'), 'utf8')
     ).toBe(existingGitignore);
-    // Their rules govern the snapshot: config.json is excluded by them.
-    expect(trackedFiles({ repoDir: testProjectDir })).toEqual([
-      '.gitignore',
-      'hello.md',
-      'world.md',
-    ]);
   });
 
   test('.git present: nothing is created', async ({
@@ -121,10 +117,9 @@ test.describe('project opening', () => {
       folderPath: testProjectDir,
     });
     await expect(fileExplorer(window).getByText('hello.md')).toBeVisible();
+    await navigateToProjectHistory({ window });
+    await expectProjectCommits({ window, messages: ['their own commit'] });
 
-    expect(commitMessages({ repoDir: testProjectDir })).toEqual([
-      'their own commit',
-    ]);
     expect(fs.existsSync(path.join(testProjectDir, '.gitignore'))).toBe(false);
   });
 

--- a/e2e/shared/git.ts
+++ b/e2e/shared/git.ts
@@ -5,22 +5,6 @@ import { execFileSync } from 'child_process';
 const git = (args: string[], cwd: string): string =>
   execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
 
-const toLines = (output: string): string[] =>
-  output.split(/\r?\n/).filter(Boolean);
-
-// Empty while the folder is not a repository yet, or has no commits yet, so
-// this is safe to poll with as the app sets a newly opened folder up.
-export const commitMessages = ({ repoDir }: { repoDir: string }): string[] => {
-  try {
-    return toLines(git(['log', '--format=%s'], repoDir));
-  } catch {
-    return [];
-  }
-};
-
-export const trackedFiles = ({ repoDir }: { repoDir: string }): string[] =>
-  toLines(git(['ls-tree', '-r', '--name-only', 'HEAD'], repoDir));
-
 export const lastCommitAuthor = ({ repoDir }: { repoDir: string }): string =>
   git(['log', '-1', '--format=%an <%ae>'], repoDir);
 
@@ -41,6 +25,6 @@ export const initRepositoryWithCommit = ({
   git(['config', 'user.name', 'Someone'], repoDir);
   git(['config', 'user.email', 'someone@example.com'], repoDir);
   git(['add', '.'], repoDir);
-  // Commit signing from a global config would prompt or fail here.
+  // Signing is enabled globally on some machines, which would fail the commit.
   git(['-c', 'commit.gpgsign=false', 'commit', '-m', message], repoDir);
 };

--- a/e2e/shared/git.ts
+++ b/e2e/shared/git.ts
@@ -1,0 +1,46 @@
+import { execFileSync } from 'child_process';
+
+// Drives the real git binary rather than the app's isomorphic-git, so specs can
+// assert on repository state independently of the code under test.
+const git = (args: string[], cwd: string): string =>
+  execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+
+const toLines = (output: string): string[] =>
+  output.split(/\r?\n/).filter(Boolean);
+
+// Empty while the folder is not a repository yet, or has no commits yet, so
+// this is safe to poll with as the app sets a newly opened folder up.
+export const commitMessages = ({ repoDir }: { repoDir: string }): string[] => {
+  try {
+    return toLines(git(['log', '--format=%s'], repoDir));
+  } catch {
+    return [];
+  }
+};
+
+export const trackedFiles = ({ repoDir }: { repoDir: string }): string[] =>
+  toLines(git(['ls-tree', '-r', '--name-only', 'HEAD'], repoDir));
+
+export const lastCommitAuthor = ({ repoDir }: { repoDir: string }): string =>
+  git(['log', '-1', '--format=%an <%ae>'], repoDir);
+
+export const hasCleanWorkingTree = ({
+  repoDir,
+}: {
+  repoDir: string;
+}): boolean => git(['status', '--porcelain'], repoDir) === '';
+
+export const initRepositoryWithCommit = ({
+  repoDir,
+  message,
+}: {
+  repoDir: string;
+  message: string;
+}): void => {
+  git(['init', '--initial-branch=main'], repoDir);
+  git(['config', 'user.name', 'Someone'], repoDir);
+  git(['config', 'user.email', 'someone@example.com'], repoDir);
+  git(['add', '.'], repoDir);
+  // Commit signing from a global config would prompt or fail here.
+  git(['-c', 'commit.gpgsign=false', 'commit', '-m', message], repoDir);
+};

--- a/e2e/shared/helpers.ts
+++ b/e2e/shared/helpers.ts
@@ -737,6 +737,71 @@ export const toggleProjectCommit = async ({
 };
 
 /**
+ * Asserts the project history sidebar holds exactly these commits, newest
+ * first, matched by message.
+ */
+export const expectProjectCommits = async ({
+  window,
+  messages,
+}: {
+  window: Page;
+  messages: string[];
+}): Promise<void> => {
+  const commitRows = window.getByTestId('project-commit-row');
+  await expect(commitRows).toHaveCount(messages.length);
+
+  await Promise.all(
+    messages.map((message, index) =>
+      expect(commitRows.nth(index)).toContainText(message)
+    )
+  );
+};
+
+// The single letter each change type is badged with in the sidebar.
+const changeTypeLabels = {
+  added: 'A',
+  modified: 'M',
+  deleted: 'D',
+  renamed: 'R',
+} as const;
+
+type ChangedPaths = Partial<Record<keyof typeof changeTypeLabels, string[]>>;
+
+/**
+ * Expands a commit and asserts exactly which files it changed and how. Paths
+ * not listed must be absent, so this pins the whole change set rather than
+ * spot-checking it.
+ */
+export const expectCommitChanges = async ({
+  window,
+  commitMessage,
+  ...changedPaths
+}: {
+  window: Page;
+  commitMessage: string;
+} & ChangedPaths): Promise<void> => {
+  await toggleProjectCommit({ window, commitMessage });
+
+  const expected = Object.entries(changedPaths).flatMap(([changeType, paths]) =>
+    paths.map((path) => ({
+      path,
+      label: changeTypeLabels[changeType as keyof typeof changeTypeLabels],
+    }))
+  );
+
+  const changedRows = window.getByTestId('changed-document-row');
+  await expect(changedRows).toHaveCount(expected.length);
+
+  await Promise.all(
+    expected.map(async ({ path, label }) => {
+      const row = changedRows.filter({ hasText: path });
+      await expect(row).toHaveCount(1);
+      await expect(row.getByTestId('change-type-badge')).toHaveText(label);
+    })
+  );
+};
+
+/**
  * Clicks a changed document row inside an expanded commit in project history.
  * The document is identified by its file name text.
  */

--- a/src/modules/domain/project/adapters/git/git-project-store/project.test.ts
+++ b/src/modules/domain/project/adapters/git/git-project-store/project.test.ts
@@ -1,0 +1,177 @@
+import * as Effect from 'effect/Effect';
+import git from 'isomorphic-git';
+
+import { parseEmail, parseUsername } from '../../../../../../modules/auth';
+import { DEFAULT_AUTHOR } from '../../../../../infrastructure/version-control';
+import { INITIAL_SNAPSHOT_COMMIT_MESSAGE } from './project';
+import { buildTestStore, PROJECT_PATH } from './test-utils';
+
+// The git-lib functions are mocked so these tests cover the store's decisions
+// (init, gitignore, snapshot) rather than version-control module internals.
+const {
+  mockRepositoryExists,
+  mockWriteGitignoreIfMissing,
+  mockStageAndCommitWorkdirChanges,
+  mockCloneRepository,
+  mockSetUserInfo,
+} = vi.hoisted(() => ({
+  mockRepositoryExists: vi.fn(),
+  mockWriteGitignoreIfMissing: vi.fn(),
+  mockStageAndCommitWorkdirChanges: vi.fn(),
+  mockCloneRepository: vi.fn(),
+  mockSetUserInfo: vi.fn(),
+}));
+
+vi.mock(
+  '../../../../../../modules/infrastructure/version-control',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('../../../../../../modules/infrastructure/version-control')
+      >();
+
+    return {
+      ...actual,
+      repositoryExists: mockRepositoryExists,
+      writeGitignoreIfMissing: mockWriteGitignoreIfMissing,
+      stageAndCommitWorkdirChanges: mockStageAndCommitWorkdirChanges,
+      cloneRepository: mockCloneRepository,
+      setUserInfo: mockSetUserInfo,
+    };
+  }
+);
+
+vi.mock('isomorphic-git', () => ({
+  default: {
+    init: vi.fn(),
+  },
+}));
+
+const mockInit = vi.mocked(git.init);
+
+const store = buildTestStore();
+
+const commitOid = 'aabbccddaabbccddaabbccddaabbccddaabbccdd';
+
+const createProject = (
+  args: Partial<Parameters<typeof store.createProject>[0]> = {}
+) =>
+  store.createProject({
+    path: PROJECT_PATH,
+    username: parseUsername('Alice'),
+    email: parseEmail('alice@example.com'),
+    ...args,
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockInit.mockResolvedValue(undefined);
+  mockWriteGitignoreIfMissing.mockReturnValue(Effect.void);
+  mockStageAndCommitWorkdirChanges.mockReturnValue(Effect.succeed(commitOid));
+  mockCloneRepository.mockReturnValue(Effect.void);
+  mockSetUserInfo.mockReturnValue(Effect.void);
+});
+
+describe('createProject', () => {
+  describe('when the folder is not a git repository yet', () => {
+    beforeEach(() => {
+      mockRepositoryExists.mockReturnValue(Effect.succeed(false));
+    });
+
+    it('initializes the repo, adds a gitignore and commits a snapshot', async () => {
+      const projectId = await Effect.runPromise(createProject());
+
+      expect(projectId).toBe(PROJECT_PATH);
+      expect(mockInit).toHaveBeenCalledWith(
+        expect.objectContaining({ dir: PROJECT_PATH })
+      );
+      expect(mockWriteGitignoreIfMissing).toHaveBeenCalledWith(
+        expect.objectContaining({ dir: PROJECT_PATH })
+      );
+      expect(mockStageAndCommitWorkdirChanges).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dir: PROJECT_PATH,
+          message: INITIAL_SNAPSHOT_COMMIT_MESSAGE,
+        })
+      );
+    });
+
+    it('attributes the snapshot to the default author', async () => {
+      await Effect.runPromise(createProject());
+
+      expect(mockStageAndCommitWorkdirChanges).toHaveBeenCalledWith(
+        expect.objectContaining({
+          author: DEFAULT_AUTHOR,
+        })
+      );
+    });
+
+    it('snapshots the folder only after the gitignore is in place', async () => {
+      await Effect.runPromise(createProject());
+
+      const gitignoreOrder =
+        mockWriteGitignoreIfMissing.mock.invocationCallOrder[0];
+      const commitOrder =
+        mockStageAndCommitWorkdirChanges.mock.invocationCallOrder[0];
+      expect(gitignoreOrder).toBeLessThan(commitOrder);
+    });
+
+    it('fails without committing when the gitignore cannot be written', async () => {
+      mockWriteGitignoreIfMissing.mockReturnValue(
+        Effect.fail(new Error('write failed'))
+      );
+
+      await Effect.runPromise(Effect.flip(createProject()));
+
+      expect(mockStageAndCommitWorkdirChanges).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the folder is already a git repository', () => {
+    beforeEach(() => {
+      mockRepositoryExists.mockReturnValue(Effect.succeed(true));
+    });
+
+    it('leaves the existing repo untouched', async () => {
+      const projectId = await Effect.runPromise(createProject());
+
+      expect(projectId).toBe(PROJECT_PATH);
+      expect(mockInit).not.toHaveBeenCalled();
+      expect(mockWriteGitignoreIfMissing).not.toHaveBeenCalled();
+      expect(mockStageAndCommitWorkdirChanges).not.toHaveBeenCalled();
+    });
+
+    it('still records the author info', async () => {
+      await Effect.runPromise(createProject());
+
+      expect(mockSetUserInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dir: PROJECT_PATH,
+          username: 'Alice',
+          email: 'alice@example.com',
+        })
+      );
+    });
+  });
+
+  describe('when cloning', () => {
+    it('does not snapshot the cloned repo, which has its own history', async () => {
+      await Effect.runPromise(
+        createProject({
+          cloneUrl: 'https://example.com/repo.git',
+          authToken: 'token',
+        })
+      );
+
+      expect(mockCloneRepository).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dir: PROJECT_PATH,
+          url: 'https://example.com/repo.git',
+        })
+      );
+      expect(mockRepositoryExists).not.toHaveBeenCalled();
+      expect(mockInit).not.toHaveBeenCalled();
+      expect(mockStageAndCommitWorkdirChanges).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/domain/project/adapters/git/git-project-store/project.ts
+++ b/src/modules/domain/project/adapters/git/git-project-store/project.ts
@@ -13,9 +13,12 @@ import {
   type ArtifactId,
   cloneRepository as cloneGitRepo,
   createGitBlobRef,
+  DEFAULT_AUTHOR,
   DEFAULT_BRANCH,
+  repositoryExists,
+  stageAndCommitWorkdirChanges,
   VersionControlRepositoryErrorTag,
-  writeGitignore,
+  writeGitignoreIfMissing,
 } from '../../../../../../modules/infrastructure/version-control';
 import { mapErrorTo } from '../../../../../../utils/errors';
 import { RepositoryError, ValidationError } from '../../../errors';
@@ -34,6 +37,8 @@ import { type ProjectStore } from '../../../ports';
 import { ensureAuthTokenIsProvided, setAuthorInfo } from './auth';
 import { getCurrentBranch } from './branching';
 import { ensureProjectIdIsFsPath } from './project-id';
+
+export const INITIAL_SNAPSHOT_COMMIT_MESSAGE = 'Set up versioning';
 
 const getDirectoryFiles = ({
   filesystem,
@@ -149,10 +154,89 @@ export const createProjectOps = ({
   isoGitHttp: IsoGitHttpApi;
   filesystem: Filesystem;
 }): ProjectOps => {
+  const cloneProject = ({
+    projectPath,
+    cloneUrl,
+    authToken: authTokenInput,
+  }: {
+    projectPath: ProjectId;
+    cloneUrl: string;
+    authToken: string | undefined;
+  }) =>
+    pipe(
+      ensureAuthTokenIsProvided(authTokenInput),
+      Effect.flatMap((authToken) =>
+        pipe(
+          cloneGitRepo({
+            isoGitFs,
+            isoGitHttp,
+            dir: projectPath,
+            url: cloneUrl,
+            authToken,
+          }),
+          Effect.catchTag(VersionControlRepositoryErrorTag, (err) =>
+            Effect.fail(new RepositoryError(err.message))
+          )
+        )
+      )
+    );
+
+  const initRepository = (projectPath: ProjectId) =>
+    pipe(
+      Effect.tryPromise({
+        try: () =>
+          git.init({
+            fs: isoGitFs,
+            dir: projectPath,
+            defaultBranch: DEFAULT_BRANCH,
+          }),
+        catch: mapErrorTo(RepositoryError, 'Git repo error'),
+      }),
+      Effect.flatMap(() =>
+        pipe(
+          writeGitignoreIfMissing({ isoGitFs, dir: projectPath }),
+          Effect.catchTag(VersionControlRepositoryErrorTag, (err) =>
+            Effect.fail(new RepositoryError(err.message))
+          )
+        )
+      )
+    );
+
+  // Records the folder in its original state, so the user can always get back to it.
+  const commitInitialSnapshot = (projectPath: ProjectId) =>
+    pipe(
+      stageAndCommitWorkdirChanges({
+        isoGitFs,
+        dir: projectPath,
+        message: INITIAL_SNAPSHOT_COMMIT_MESSAGE,
+        author: DEFAULT_AUTHOR,
+      }),
+      Effect.catchTag(VersionControlRepositoryErrorTag, (err) =>
+        Effect.fail(new RepositoryError(err.message))
+      )
+    );
+
+  // An existing repo has its own history and .gitignore, so it is left as it was found.
+  const setUpVersioning = (projectPath: ProjectId) =>
+    pipe(
+      repositoryExists({ isoGitFs, dir: projectPath }),
+      Effect.catchTag(VersionControlRepositoryErrorTag, (err) =>
+        Effect.fail(new RepositoryError(err.message))
+      ),
+      Effect.flatMap((exists) =>
+        exists
+          ? Effect.void
+          : pipe(
+              initRepository(projectPath),
+              Effect.flatMap(() => commitInitialSnapshot(projectPath))
+            )
+      )
+    );
+
   const createProject: ProjectOps['createProject'] = ({
     path,
     cloneUrl,
-    authToken: authTokenInput,
+    authToken,
     username,
     email,
   }) =>
@@ -163,42 +247,8 @@ export const createProjectOps = ({
       }),
       Effect.tap((projectPath) =>
         cloneUrl
-          ? pipe(
-              ensureAuthTokenIsProvided(authTokenInput),
-              Effect.flatMap((authToken) =>
-                pipe(
-                  cloneGitRepo({
-                    isoGitFs,
-                    isoGitHttp,
-                    dir: projectPath,
-                    url: cloneUrl,
-                    authToken,
-                  }),
-                  Effect.catchTag(VersionControlRepositoryErrorTag, (err) =>
-                    Effect.fail(new RepositoryError(err.message))
-                  )
-                )
-              )
-            )
-          : pipe(
-              Effect.tryPromise({
-                try: () =>
-                  git.init({
-                    fs: isoGitFs,
-                    dir: projectPath,
-                    defaultBranch: DEFAULT_BRANCH,
-                  }),
-                catch: mapErrorTo(RepositoryError, 'Git repo error'),
-              }),
-              Effect.tap(() =>
-                pipe(
-                  writeGitignore({ isoGitFs, dir: projectPath }),
-                  Effect.catchTag(VersionControlRepositoryErrorTag, (err) =>
-                    Effect.fail(new RepositoryError(err.message))
-                  )
-                )
-              )
-            )
+          ? cloneProject({ projectPath, cloneUrl, authToken })
+          : setUpVersioning(projectPath)
       ),
       Effect.tap((projectPath) =>
         setAuthorInfo({ isoGitFs, projectId: projectPath, username, email })

--- a/src/modules/infrastructure/version-control/constants/default-author.ts
+++ b/src/modules/infrastructure/version-control/constants/default-author.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_AUTHOR_NAME = 'v2 Bot';
+export const DEFAULT_AUTHOR_EMAIL = 'bot@v2editor.com';

--- a/src/modules/infrastructure/version-control/git-lib/committing/authorship.ts
+++ b/src/modules/infrastructure/version-control/git-lib/committing/authorship.ts
@@ -1,0 +1,38 @@
+import * as Effect from 'effect/Effect';
+import { pipe } from 'effect/Function';
+
+import { DEFAULT_AUTHOR_EMAIL, DEFAULT_AUTHOR_NAME } from '../../constants';
+import { RepositoryError } from '../../errors';
+import { getUserInfo } from '../config';
+import { type IsoGitDeps } from '../types';
+
+export type CommitAuthor = {
+  name: string;
+  email: string;
+};
+
+export const DEFAULT_AUTHOR: CommitAuthor = {
+  name: DEFAULT_AUTHOR_NAME,
+  email: DEFAULT_AUTHOR_EMAIL,
+};
+
+export type ResolveAuthorArgs = Omit<IsoGitDeps, 'isoGitHttp'> & {
+  author?: CommitAuthor;
+};
+
+// Without an explicit author, the commit is attributed to whoever the repo
+// config says is writing, falling back to the default (bot) author.
+export const resolveAuthor = ({
+  isoGitFs,
+  dir,
+  author,
+}: ResolveAuthorArgs): Effect.Effect<CommitAuthor, RepositoryError, never> =>
+  author
+    ? Effect.succeed(author)
+    : pipe(
+        getUserInfo({ isoGitFs, dir }),
+        Effect.map((repoUserInfo) => ({
+          name: repoUserInfo.username ?? DEFAULT_AUTHOR.name,
+          email: repoUserInfo.email ?? DEFAULT_AUTHOR.email,
+        }))
+      );

--- a/src/modules/infrastructure/version-control/git-lib/committing/index.test.ts
+++ b/src/modules/infrastructure/version-control/git-lib/committing/index.test.ts
@@ -2,9 +2,9 @@ import * as Effect from 'effect/Effect';
 import git from 'isomorphic-git';
 import { type PromiseFsClient as IsoGitFsApi } from 'isomorphic-git';
 
-import { DEFAULT_AUTHOR_NAME } from '../../constants';
 import {
   commitStagedChanges,
+  DEFAULT_AUTHOR,
   stageAndCommitChangesToFiles,
   stageAndCommitWorkdirChanges,
 } from './index';
@@ -78,7 +78,7 @@ describe('commitStagedChanges', () => {
       mockGetConfig.mockResolvedValue(undefined);
     });
 
-    it('uses DEFAULT_AUTHOR_NAME as the commit author', async () => {
+    it('uses the default author', async () => {
       mockCommit.mockResolvedValue(commitOid);
 
       await Effect.runPromise(
@@ -87,7 +87,30 @@ describe('commitStagedChanges', () => {
 
       expect(mockCommit).toHaveBeenCalledWith(
         expect.objectContaining({
-          author: { name: DEFAULT_AUTHOR_NAME, email: undefined },
+          author: DEFAULT_AUTHOR,
+        })
+      );
+    });
+  });
+
+  describe('with an explicit author', () => {
+    it('commits as that author without reading the repo config', async () => {
+      stubAuthorConfig();
+      mockCommit.mockResolvedValue(commitOid);
+
+      await Effect.runPromise(
+        commitStagedChanges({
+          isoGitFs: mockFs,
+          dir,
+          message: 'msg',
+          author: DEFAULT_AUTHOR,
+        })
+      );
+
+      expect(mockGetConfig).not.toHaveBeenCalled();
+      expect(mockCommit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          author: DEFAULT_AUTHOR,
         })
       );
     });
@@ -134,6 +157,26 @@ describe('stageAndCommitWorkdirChanges', () => {
       const commitOrder = mockCommit.mock.invocationCallOrder[0];
       expect(addOrder).toBeLessThan(commitOrder);
     });
+  });
+
+  it('forwards an explicit author to the commit', async () => {
+    mockAdd.mockResolvedValue(undefined);
+    mockCommit.mockResolvedValue(commitOid);
+
+    await Effect.runPromise(
+      stageAndCommitWorkdirChanges({
+        isoGitFs: mockFs,
+        dir,
+        message: 'msg',
+        author: DEFAULT_AUTHOR,
+      })
+    );
+
+    expect(mockCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        author: DEFAULT_AUTHOR,
+      })
+    );
   });
 
   it('fails with RepositoryError when the staging step fails', async () => {

--- a/src/modules/infrastructure/version-control/git-lib/committing/index.ts
+++ b/src/modules/infrastructure/version-control/git-lib/committing/index.ts
@@ -3,39 +3,39 @@ import { pipe } from 'effect/Function';
 import git from 'isomorphic-git';
 
 import { mapErrorTo } from '../../../../../utils/errors';
-import { DEFAULT_AUTHOR_NAME } from '../../constants';
 import { RepositoryError } from '../../errors';
 import { type Commit } from '../../models';
 import { parseGitCommitHash } from '../../models';
-import { getUserInfo } from '../config';
 import { stageFiles, stageWorkdirChanges } from '../staging-area';
 import { type IsoGitDeps } from '../types';
+import { type CommitAuthor, resolveAuthor } from './authorship';
+
+export * from './authorship';
 
 export type CommitStagedChangesArgs = Omit<IsoGitDeps, 'isoGitHttp'> & {
   message: string;
+  author?: CommitAuthor;
 };
 
 export const commitStagedChanges = ({
   isoGitFs,
   dir,
   message,
+  author,
 }: CommitStagedChangesArgs): Effect.Effect<
   Commit['id'],
   RepositoryError,
   never
 > =>
   pipe(
-    getUserInfo({ isoGitFs, dir }),
-    Effect.flatMap((repoUserInfo) =>
+    resolveAuthor({ isoGitFs, dir, author }),
+    Effect.flatMap((commitAuthor) =>
       Effect.tryPromise({
         try: () =>
           git.commit({
             fs: isoGitFs,
             dir,
-            author: {
-              name: repoUserInfo.username ?? DEFAULT_AUTHOR_NAME,
-              email: repoUserInfo.email ?? undefined,
-            },
+            author: commitAuthor,
             message,
           }),
         catch: mapErrorTo(
@@ -57,12 +57,14 @@ export type StageAndCommitWorkdirChangesArgs = Omit<
   'isoGitHttp'
 > & {
   message: string;
+  author?: CommitAuthor;
 };
 
 export const stageAndCommitWorkdirChanges = ({
   isoGitFs,
   dir,
   message,
+  author,
 }: StageAndCommitWorkdirChangesArgs): Effect.Effect<
   Commit['id'],
   RepositoryError,
@@ -70,7 +72,9 @@ export const stageAndCommitWorkdirChanges = ({
 > =>
   pipe(
     stageWorkdirChanges({ isoGitFs, dir }),
-    Effect.flatMap(() => commitStagedChanges({ isoGitFs, dir, message }))
+    Effect.flatMap(() =>
+      commitStagedChanges({ isoGitFs, dir, message, author })
+    )
   );
 
 export type StageAndCommitChangesToFilesArgs = Omit<

--- a/src/modules/infrastructure/version-control/git-lib/fs-utils.ts
+++ b/src/modules/infrastructure/version-control/git-lib/fs-utils.ts
@@ -1,0 +1,36 @@
+import * as Effect from 'effect/Effect';
+import { pipe } from 'effect/Function';
+import { type PromiseFsClient as IsoGitFsApi } from 'isomorphic-git';
+
+import {
+  NotFoundError,
+  RepositoryError,
+  VersionControlNotFoundErrorTag,
+} from '../errors';
+
+export type PathExistsArgs = {
+  isoGitFs: IsoGitFsApi;
+  filePath: string;
+};
+
+const isMissingPathError = (err: unknown): boolean =>
+  typeof err === 'object' &&
+  err !== null &&
+  'code' in err &&
+  (err.code === 'ENOENT' || err.code === 'ENOTDIR');
+
+export const pathExists = ({
+  isoGitFs,
+  filePath,
+}: PathExistsArgs): Effect.Effect<boolean, RepositoryError, never> =>
+  pipe(
+    Effect.tryPromise({
+      try: () => isoGitFs.promises.stat(filePath),
+      catch: (err) =>
+        isMissingPathError(err)
+          ? new NotFoundError(`${filePath} does not exist`)
+          : new RepositoryError(`Error in checking if ${filePath} exists`),
+    }),
+    Effect.map(() => true),
+    Effect.catchTag(VersionControlNotFoundErrorTag, () => Effect.succeed(false))
+  );

--- a/src/modules/infrastructure/version-control/git-lib/gitignore.test.ts
+++ b/src/modules/infrastructure/version-control/git-lib/gitignore.test.ts
@@ -1,0 +1,63 @@
+import * as Effect from 'effect/Effect';
+import { type PromiseFsClient as IsoGitFsApi } from 'isomorphic-git';
+import path from 'path';
+
+import { writeGitignoreIfMissing } from './gitignore';
+
+const dir = '/test-repo';
+const mockStat = vi.fn();
+const mockWriteFile = vi.fn();
+const mockFs = {
+  promises: { stat: mockStat, writeFile: mockWriteFile },
+} as unknown as IsoGitFsApi;
+
+const fsError = (code: string) => Object.assign(new Error(code), { code });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('writeGitignoreIfMissing', () => {
+  it('writes the default gitignore when the folder has none', async () => {
+    mockStat.mockRejectedValue(fsError('ENOENT'));
+    mockWriteFile.mockResolvedValue(undefined);
+
+    await Effect.runPromise(writeGitignoreIfMissing({ isoGitFs: mockFs, dir }));
+
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    const [writtenPath, contents] = mockWriteFile.mock.calls[0];
+    expect(writtenPath).toBe(path.join(dir, '.gitignore'));
+    expect(contents).toContain('.DS_Store');
+  });
+
+  it('leaves an existing gitignore alone', async () => {
+    mockStat.mockResolvedValue({ isFile: () => true });
+
+    await Effect.runPromise(writeGitignoreIfMissing({ isoGitFs: mockFs, dir }));
+
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('fails with RepositoryError when the write fails', async () => {
+    mockStat.mockRejectedValue(fsError('ENOENT'));
+    mockWriteFile.mockRejectedValue(new Error('write failed'));
+
+    const error = await Effect.runPromise(
+      Effect.flip(writeGitignoreIfMissing({ isoGitFs: mockFs, dir }))
+    );
+
+    expect(error._tag).toBe('VersionControlRepositoryError');
+  });
+
+  // Writing over a gitignore we merely failed to read would destroy it.
+  it('fails without writing when the existing gitignore cannot be read', async () => {
+    mockStat.mockRejectedValue(fsError('EACCES'));
+
+    const error = await Effect.runPromise(
+      Effect.flip(writeGitignoreIfMissing({ isoGitFs: mockFs, dir }))
+    );
+
+    expect(error._tag).toBe('VersionControlRepositoryError');
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/infrastructure/version-control/git-lib/gitignore.ts
+++ b/src/modules/infrastructure/version-control/git-lib/gitignore.ts
@@ -1,8 +1,10 @@
 import * as Effect from 'effect/Effect';
+import { pipe } from 'effect/Function';
 import path from 'path';
 
 import { mapErrorTo } from '../../../../utils/errors';
 import { RepositoryError } from '../errors';
+import { pathExists } from './fs-utils';
 import { IsoGitDeps } from './types';
 
 export type WriteGitignoreArgs = Omit<IsoGitDeps, 'isoGitHttp'>;
@@ -23,16 +25,23 @@ Desktop.ini
 *.swo
 `.trim() + '\n';
 
-export const writeGitignore = ({
+export const writeGitignoreIfMissing = ({
   isoGitFs,
   dir,
 }: WriteGitignoreArgs): Effect.Effect<void, RepositoryError, never> =>
-  Effect.tryPromise({
-    try: () =>
-      isoGitFs.promises.writeFile(
-        path.join(dir, '.gitignore'),
-        gitignoreContent,
-        'utf8'
-      ),
-    catch: mapErrorTo(RepositoryError, 'Error writing MERGE_HEAD'),
-  });
+  pipe(
+    pathExists({ isoGitFs, filePath: path.join(dir, '.gitignore') }),
+    Effect.flatMap((exists) =>
+      exists
+        ? Effect.void
+        : Effect.tryPromise({
+            try: () =>
+              isoGitFs.promises.writeFile(
+                path.join(dir, '.gitignore'),
+                gitignoreContent,
+                'utf8'
+              ),
+            catch: mapErrorTo(RepositoryError, 'Error writing .gitignore'),
+          })
+    )
+  );

--- a/src/modules/infrastructure/version-control/git-lib/merging/index.ts
+++ b/src/modules/infrastructure/version-control/git-lib/merging/index.ts
@@ -7,7 +7,6 @@ import path from 'path';
 
 import { fromNullable } from '../../../../../utils/effect';
 import { mapErrorTo } from '../../../../../utils/errors';
-import { DEFAULT_AUTHOR_NAME } from '../../constants';
 import {
   MergeConflictError,
   NotFoundError,
@@ -27,7 +26,7 @@ import {
   parseGitCommitHash,
 } from '../../models';
 import { deleteBranch, switchToBranch } from '../branching';
-import { stageAndCommitWorkdirChanges } from '../committing';
+import { DEFAULT_AUTHOR, stageAndCommitWorkdirChanges } from '../committing';
 import { IsoGitDeps } from '../types';
 
 export type MergeAndDeleteBranchArgs = Omit<IsoGitDeps, 'isoGitHttp'> & {
@@ -188,9 +187,7 @@ export const mergeAndDeleteBranch = ({
             dir,
             ours: into,
             theirs: from,
-            author: {
-              name: DEFAULT_AUTHOR_NAME,
-            },
+            author: DEFAULT_AUTHOR,
             abortOnConflict: false,
           }),
         catch: (err) => {

--- a/src/modules/infrastructure/version-control/git-lib/repositories/index.test.ts
+++ b/src/modules/infrastructure/version-control/git-lib/repositories/index.test.ts
@@ -1,0 +1,52 @@
+import * as Effect from 'effect/Effect';
+import { type PromiseFsClient as IsoGitFsApi } from 'isomorphic-git';
+import path from 'path';
+
+import { repositoryExists } from './index';
+
+const dir = '/test-repo';
+const mockStat = vi.fn();
+const mockFs = { promises: { stat: mockStat } } as unknown as IsoGitFsApi;
+
+const fsError = (code: string) => Object.assign(new Error(code), { code });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('repositoryExists', () => {
+  // Whatever `.git` turns out to be — a directory, or a file in a worktree or
+  // submodule — the folder is a repository.
+  it('is true when the folder has a .git entry', async () => {
+    mockStat.mockResolvedValue({});
+
+    const result = await Effect.runPromise(
+      repositoryExists({ isoGitFs: mockFs, dir })
+    );
+
+    expect(result).toBe(true);
+    expect(mockStat).toHaveBeenCalledWith(path.join(dir, '.git'));
+  });
+
+  it('is false when .git is missing', async () => {
+    mockStat.mockRejectedValue(fsError('ENOENT'));
+
+    const result = await Effect.runPromise(
+      repositoryExists({ isoGitFs: mockFs, dir })
+    );
+
+    expect(result).toBe(false);
+  });
+
+  // An unreadable folder is not the same as one without a repo — reporting it
+  // as absent would have the caller initialize a repo over the top of it.
+  it('fails when the folder cannot be read', async () => {
+    mockStat.mockRejectedValue(fsError('EACCES'));
+
+    const error = await Effect.runPromise(
+      Effect.flip(repositoryExists({ isoGitFs: mockFs, dir }))
+    );
+
+    expect(error._tag).toBe('VersionControlRepositoryError');
+  });
+});

--- a/src/modules/infrastructure/version-control/git-lib/repositories/index.ts
+++ b/src/modules/infrastructure/version-control/git-lib/repositories/index.ts
@@ -1,10 +1,20 @@
 import * as Effect from 'effect/Effect';
 import git from 'isomorphic-git';
+import path from 'path';
 
 import { mapErrorTo } from '../../../../../utils/errors';
 import { RepositoryError } from '../../errors';
 import { authCallback } from '../auth';
+import { pathExists } from '../fs-utils';
 import { IsoGitDeps } from '../types';
+
+export type RepositoryExistsArgs = Omit<IsoGitDeps, 'isoGitHttp'>;
+
+export const repositoryExists = ({
+  isoGitFs,
+  dir,
+}: RepositoryExistsArgs): Effect.Effect<boolean, RepositoryError, never> =>
+  pathExists({ isoGitFs, filePath: path.join(dir, '.git') });
 
 type CloneRepositoryArgs = IsoGitDeps & {
   url: string;

--- a/src/renderer/src/components/versioning/ChangeTypeBadge.tsx
+++ b/src/renderer/src/components/versioning/ChangeTypeBadge.tsx
@@ -38,6 +38,7 @@ export const ChangeTypeBadge = ({
 
   return (
     <span
+      data-testid="change-type-badge"
       className={clsx(
         'inline-flex h-5 w-5 items-center justify-center rounded text-xs font-semibold',
         badgeProperties.className


### PR DESCRIPTION
## Description

Pristine state & `.gitignore` commit on project setup: commit the untouched condition of the folder (with a .gitignore) before the editor touches anything. Ignore if the git folder already exists.

## Related Issue

Closes #355 
