### PR TITLE
feat: add command palette action to copy the document as Markdown

### DIFF
--- a/src/renderer/src/app-state/current-document/exporting/use-export.ts
+++ b/src/renderer/src/app-state/current-document/exporting/use-export.ts
@@ -16,6 +16,11 @@ import {
 } from '../../../../../modules/domain/rich-text';
 import { RepresentationTransformContext } from '../../../../../modules/domain/rich-text/react/representation-transform-context';
 import {
+  createErrorNotification,
+  createSuccessNotification,
+  NotificationsContext,
+} from '../../../../../modules/infrastructure/notifications/browser';
+import {
   ExportTemplatesContext,
   exportTemplateToCss,
 } from '../../../../../modules/personalization/browser';
@@ -33,6 +38,7 @@ export const useExport = () => {
   );
   const { adapter } = useContext(RepresentationTransformContext);
   const { activeTemplate } = useContext(ExportTemplatesContext);
+  const { dispatchNotification } = useContext(NotificationsContext);
   const { projectId: projectIdParam } = useParams();
   const documentId = useCurrentDocumentId();
   const { currentArtifact } = useContext(ProjectContext);
@@ -134,11 +140,35 @@ export const useExport = () => {
 
   const exportToPDF = exportToBinary(binaryRichTextRepresentations.PDF);
 
+  const copyTextToClipboard =
+    (representation: TextRichTextRepresentation) => async () => {
+      try {
+        const text = await getExportText(representation);
+        await navigator.clipboard.writeText(text);
+        dispatchNotification(
+          createSuccessNotification({
+            title: 'Copied to Clipboard',
+            message: 'The document content was copied to the clipboard.',
+          })
+        );
+      } catch (err) {
+        console.error(err);
+        dispatchNotification(
+          createErrorNotification({
+            title: 'Copy to Clipboard Error',
+            message:
+              'An error happened when trying to copy the document to the clipboard. Please try again.',
+          })
+        );
+      }
+    };
+
   return {
     getExportText,
     getExportBinaryData,
     exportToText,
     exportToBinary,
     exportToPDF,
+    copyTextToClipboard,
   };
 };

--- a/src/renderer/src/pages/project/shared/command-palette/index.tsx
+++ b/src/renderer/src/pages/project/shared/command-palette/index.tsx
@@ -47,7 +47,8 @@ export const ProjectCommandPalette = ({
   const { selection, startCreateDirectory } = useDocumentExplorerTree();
   const clearWebStorage = useClearWebStorage();
 
-  const { exportToText, exportToBinary, exportToPDF } = useExport();
+  const { exportToText, exportToBinary, exportToPDF, copyTextToClipboard } =
+    useExport();
 
   const openableDocuments = useMemo(
     () =>
@@ -105,6 +106,10 @@ export const ProjectCommandPalette = ({
           },
         ]
       : []),
+    {
+      name: 'Copy as Markdown',
+      onActionSelection: copyTextToClipboard(richTextRepresentations.MARKDOWN),
+    },
     {
       name: keyBindings.ctrlShiftM.command,
       shortcut: keyBindings.ctrlShiftM.keyBinding,


### PR DESCRIPTION
Closes #178

Adds a **Copy as Markdown** action to the command palette's current-document. It reuses the existing export path (`getExportText`) to produce the Markdown, writes it to the clipboard, and dispatches a success or error notification.

