### PR TITLE
feat: add command palette action to copy the selection as Markdown

### DIFF
--- a/e2e/exports/markdown-selection.spec.ts
+++ b/e2e/exports/markdown-selection.spec.ts
@@ -1,0 +1,100 @@
+import { Page } from '@playwright/test';
+
+import { expect, test } from '../shared/fixtures';
+import {
+  clearClipboard,
+  focusParagraph,
+  openCommandPalette,
+  openHelloMd,
+  openProjectFolder,
+  readClipboardText,
+  runPaletteAction,
+} from '../shared/helpers';
+
+/**
+ * Selects the body paragraph ("This is a test document.") of hello.md.
+ *
+ * The editor can remount shortly after a document opens (sync/save cycles),
+ * which resets the selection — so re-select until the selection sticks.
+ */
+const selectHelloMdParagraph = async ({
+  window,
+}: {
+  window: Page;
+}): Promise<void> => {
+  await expect
+    .poll(
+      async () => {
+        await focusParagraph({ window });
+        await window.keyboard.press('Home');
+        await window.keyboard.press('Shift+End');
+
+        // Give a pending editor remount the chance to wipe the selection, so
+        // we only proceed with a selection that has settled.
+        await window.waitForTimeout(300);
+        return window.evaluate(() => document.getSelection()?.toString());
+      },
+      { timeout: 15_000 }
+    )
+    .toBe('This is a test document.');
+};
+
+test.describe('copy selection as markdown', () => {
+  test('copies only the selection as Markdown to the clipboard', async ({
+    electronApp,
+    window,
+    testProjectDir,
+  }) => {
+    await openProjectFolder({
+      electronApp,
+      window,
+      folderPath: testProjectDir,
+    });
+    await openHelloMd({ window });
+
+    // Select the body paragraph but not the title
+    await selectHelloMdParagraph({ window });
+
+    await clearClipboard({ electronApp });
+
+    await runPaletteAction({
+      window,
+      actionName: 'Copy selection as Markdown',
+    });
+
+    // The success notification confirms the clipboard write completed
+    await expect(window.getByText('Copied to Clipboard')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const clipboardText = await readClipboardText({ electronApp });
+    expect(clipboardText).toContain('This is a test document.');
+    // The heading was not part of the selection, so it must not be copied
+    expect(clipboardText).not.toContain('Hello');
+  });
+
+  test('does not offer the selection action when nothing is selected', async ({
+    electronApp,
+    window,
+    testProjectDir,
+  }) => {
+    await openProjectFolder({
+      electronApp,
+      window,
+      folderPath: testProjectDir,
+    });
+    await openHelloMd({ window });
+
+    await openCommandPalette({ window });
+
+    await expect(
+      window.getByRole('option', { name: 'Copy as Markdown', exact: true })
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(
+      window.getByRole('option', {
+        name: 'Copy selection as Markdown',
+        exact: true,
+      })
+    ).toBeHidden();
+  });
+});

--- a/src/modules/domain/rich-text/prosemirror/selection.test.ts
+++ b/src/modules/domain/rich-text/prosemirror/selection.test.ts
@@ -1,5 +1,17 @@
-import { getSelectedText } from './selection';
-import { editorState, para, withCursorAt, withSelectionAt } from './test-utils';
+import { type Node as ProseMirrorNode } from 'prosemirror-model';
+import { EditorState, NodeSelection, TextSelection } from 'prosemirror-state';
+
+import { schema } from './schema';
+import { docFromSelection, getSelectedText } from './selection';
+import {
+  editorState,
+  figureWith,
+  heading,
+  para,
+  topLevelTypes,
+  withCursorAt,
+  withSelectionAt,
+} from './test-utils';
 
 describe('getSelectedText', () => {
   it('returns the selected text within a single block', () => {
@@ -26,5 +38,212 @@ describe('getSelectedText', () => {
       pos: 2,
     });
     expect(getSelectedText(state)).toBe(null);
+  });
+});
+
+const listItem = (children: ProseMirrorNode[]): ProseMirrorNode =>
+  schema.node('list_item', null, children);
+
+const bulletList = (items: ProseMirrorNode[]): ProseMirrorNode =>
+  schema.node('bullet_list', null, items);
+
+const orderedList = (items: ProseMirrorNode[]): ProseMirrorNode =>
+  schema.node('ordered_list', { order: 1 }, items);
+
+const blockquote = (children: ProseMirrorNode[]): ProseMirrorNode =>
+  schema.node('blockquote', null, children);
+
+const codeBlock = (text: string, language = 'python'): ProseMirrorNode =>
+  schema.node('code_block', { language }, [schema.text(text)]);
+
+// Absolute position of the first occurrence of `text` in the doc.
+const posOf = (docNode: ProseMirrorNode, text: string): number => {
+  let result = -1;
+  docNode.descendants((node, pos) => {
+    if (result !== -1) return false;
+    if (node.isText && node.text!.includes(text)) {
+      result = pos + node.text!.indexOf(text);
+    }
+    return result === -1;
+  });
+  if (result === -1) throw new Error(`Text not found in doc: ${text}`);
+  return result;
+};
+
+// Selects from the start of `fromText` to the end of `toText` (defaults to
+// `fromText`, i.e. selects that text).
+const selectText = (
+  state: EditorState,
+  fromText: string,
+  toText = fromText
+): EditorState => {
+  const from = posOf(state.doc, fromText);
+  const to = posOf(state.doc, toText) + toText.length;
+  return state.apply(
+    state.tr.setSelection(TextSelection.create(state.doc, from, to))
+  );
+};
+
+const selectNode = (state: EditorState, typeName: string): EditorState => {
+  let nodePos = -1;
+  state.doc.descendants((node, pos) => {
+    if (nodePos !== -1) return false;
+    if (node.type.name === typeName) {
+      nodePos = pos;
+    }
+    return nodePos === -1;
+  });
+  return state.apply(
+    state.tr.setSelection(NodeSelection.create(state.doc, nodePos))
+  );
+};
+
+describe('docFromSelection', () => {
+  it('returns null for an empty selection', () => {
+    const state = withCursorAt({ state: editorState([para('hello')]), pos: 2 });
+    expect(docFromSelection(state)).toBeNull();
+  });
+
+  it('copies a word from a paragraph as a bare paragraph', () => {
+    const state = selectText(editorState([para('hello world')]), 'hello');
+    const result = docFromSelection(state)!;
+    expect(result.content.content.map((n) => n.type.name)).toEqual([
+      'paragraph',
+    ]);
+    expect(result.textContent).toBe('hello');
+  });
+
+  it('keeps both blocks when the selection spans two paragraphs', () => {
+    const state = selectText(
+      editorState([para('first'), para('second')]),
+      'rst',
+      'se'
+    );
+    const result = docFromSelection(state)!;
+    expect(result.content.content.map((n) => n.type.name)).toEqual([
+      'paragraph',
+      'paragraph',
+    ]);
+    expect(result.textContent).toBe('rstse');
+  });
+
+  it('keeps a heading partially covered by a cross-block selection', () => {
+    const state = selectText(
+      editorState([heading({ text: 'Head' }), para('body')]),
+      'ead',
+      'bo'
+    );
+    const result = docFromSelection(state)!;
+    expect(result.content.content.map((n) => n.type.name)).toEqual([
+      'heading',
+      'paragraph',
+    ]);
+  });
+
+  it('keeps the heading (and its level) for a selection inside it', () => {
+    const state = selectText(
+      editorState([heading({ text: 'Title here', level: 2 })]),
+      'Title'
+    );
+    const result = docFromSelection(state)!;
+    expect(result.firstChild!.type.name).toBe('heading');
+    expect(result.firstChild!.attrs.level).toBe(2);
+    expect(result.textContent).toBe('Title');
+  });
+
+  it('keeps the bullet list when the selection spans two of its items', () => {
+    const state = selectText(
+      editorState([
+        bulletList([listItem([para('one')]), listItem([para('two')])]),
+      ]),
+      'ne',
+      't'
+    );
+    const result = docFromSelection(state)!;
+    expect(result.content.content.map((n) => n.type.name)).toEqual([
+      'bullet_list',
+    ]);
+    expect(result.firstChild!.childCount).toBe(2);
+    expect(result.textContent).toBe('net');
+  });
+
+  it('does not turn a partially selected ordered list into another list type', () => {
+    const state = selectText(
+      editorState([
+        orderedList([listItem([para('one')]), listItem([para('two')])]),
+      ]),
+      'ne',
+      't'
+    );
+    const result = docFromSelection(state)!;
+    expect(result.firstChild!.type.name).toBe('ordered_list');
+  });
+
+  it('drops the list for a selection inside a single item', () => {
+    const state = selectText(
+      editorState([
+        bulletList([listItem([para('one')]), listItem([para('two')])]),
+      ]),
+      'ne'
+    );
+    const result = docFromSelection(state)!;
+    expect(result.content.content.map((n) => n.type.name)).toEqual([
+      'paragraph',
+    ]);
+    expect(result.textContent).toBe('ne');
+  });
+
+  it('drops the blockquote when its paragraphs are selected from within', () => {
+    const state = selectText(
+      editorState([blockquote([para('aa'), para('bb')])]),
+      'aa',
+      'bb'
+    );
+    const result = docFromSelection(state)!;
+    expect(result.content.content.map((n) => n.type.name)).toEqual([
+      'paragraph',
+      'paragraph',
+    ]);
+  });
+
+  it('keeps a partially selected code block, including its language', () => {
+    const state = selectText(editorState([codeBlock('print hello')]), 'print');
+    const result = docFromSelection(state)!;
+    expect(result.firstChild!.type.name).toBe('code_block');
+    expect(result.firstChild!.attrs.language).toBe('python');
+    expect(result.textContent).toBe('print');
+  });
+
+  it('copies a node selection (figure) as-is', () => {
+    const state = selectNode(
+      editorState([para('x'), figureWith({ src: 'a.jpg' })]),
+      'figure'
+    );
+    const result = docFromSelection(state)!;
+    expect(topLevelTypes(state)).toEqual(['paragraph', 'figure']);
+    expect(result.content.content.map((n) => n.type.name)).toEqual(['figure']);
+  });
+
+  it('falls back to plain text when the cut cannot be closed into a valid doc', () => {
+    // Selecting from a list item's trailing code block into the next item
+    // leaves the first item without its required leading paragraph.
+    const state = editorState([
+      bulletList([
+        listItem([para('a'), codeBlock('bb')]),
+        listItem([para('c')]),
+      ]),
+    ]);
+    const from = posOf(state.doc, 'bb') + 1;
+    const to = posOf(state.doc, 'c') + 1;
+    const selected = state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, from, to))
+    );
+    const result = docFromSelection(selected)!;
+    expect(result.content.content.map((n) => n.type.name)).toEqual([
+      'paragraph',
+      'paragraph',
+    ]);
+    expect(result.textContent).toBe('bc');
+    result.check();
   });
 });

--- a/src/modules/domain/rich-text/prosemirror/selection.ts
+++ b/src/modules/domain/rich-text/prosemirror/selection.ts
@@ -1,4 +1,8 @@
-import type { MarkType } from 'prosemirror-model';
+import {
+  Fragment,
+  type MarkType,
+  type Node as ProseMirrorNode,
+} from 'prosemirror-model';
 import {
   EditorState,
   Plugin,
@@ -105,6 +109,80 @@ export const getSelectedText = (state: EditorState): string | null => {
   // Without a block separator, text from adjacent blocks would be glued
   // together into a string that doesn't occur in the document.
   return state.doc.textBetween(selection.from, selection.to, '\n');
+};
+
+// Last resort for selections whose structure cannot be closed into a valid
+// document: just the selected text, one paragraph per block.
+const plainTextDocFromSelection = (
+  state: EditorState,
+  from: number,
+  to: number
+): ProseMirrorNode => {
+  const { schema } = state;
+  const paragraphs = state.doc
+    .textBetween(from, to, '\n')
+    .split('\n')
+    .map((line) =>
+      schema.nodes.paragraph.create(null, line ? [schema.text(line)] : null)
+    );
+
+  return state.doc.type.create(null, Fragment.from(paragraphs));
+};
+
+// Builds the smallest valid standalone document that contains the current
+// selection, keeping only the structural context the content cannot stand
+// without: list items keep their list (and its type), a partial heading or
+// code block keeps its block, but e.g. a blockquote around fully selected
+// paragraphs is dropped. Returns null when the selection is empty.
+export const docFromSelection = (
+  state: EditorState
+): ProseMirrorNode | null => {
+  const { selection, doc } = state;
+
+  if (selection.empty) {
+    return null;
+  }
+
+  const { $from, from, to } = selection;
+  const docType = doc.type;
+
+  // Cut the selected range out of the deepest node that contains all of it.
+  const sharedDepth = $from.sharedDepth(to);
+  const contentStart = $from.start(sharedDepth);
+  let fragment = $from
+    .node(sharedDepth)
+    .content.cut(from - contentStart, to - contentStart);
+
+  // Wrap the fragment in copies of its ancestors until it is valid top-level
+  // document content. createAndFill patches up boundary nodes that the cut
+  // left without their required children.
+  let depth = sharedDepth;
+  while (depth > 0 && !docType.validContent(fragment)) {
+    const ancestor = $from.node(depth);
+    const wrapped = ancestor.type.createAndFill(ancestor.attrs, fragment);
+
+    if (!wrapped) {
+      break;
+    }
+
+    fragment = Fragment.from(wrapped);
+    depth -= 1;
+  }
+
+  if (docType.validContent(fragment)) {
+    // Deliberately not carrying over the source doc's attrs (pandocMeta):
+    // copying a selection should not drag document metadata along.
+    const candidate = docType.create(null, fragment);
+
+    try {
+      candidate.check();
+      return candidate;
+    } catch {
+      // Fall through to the plain-text fallback below.
+    }
+  }
+
+  return plainTextDocFromSelection(state, from, to);
 };
 
 export const findLinkAtSelection = ({

--- a/src/renderer/src/app-state/current-document/exporting/use-export.ts
+++ b/src/renderer/src/app-state/current-document/exporting/use-export.ts
@@ -10,10 +10,12 @@ import {
   type BinaryRichTextRepresentation,
   binaryRichTextRepresentations,
   getDocumentRichTextContent,
+  prosemirror,
   richTextRepresentationExtensions,
   richTextRepresentations,
   type TextRichTextRepresentation,
 } from '../../../../../modules/domain/rich-text';
+import { ProseMirrorContext } from '../../../../../modules/domain/rich-text/react/prosemirror-context';
 import { RepresentationTransformContext } from '../../../../../modules/domain/rich-text/react/representation-transform-context';
 import {
   createErrorNotification,
@@ -32,11 +34,14 @@ import {
   useExportAssetMounts,
 } from './use-export-asset-mounts';
 
+const { docFromSelection } = prosemirror;
+
 export const useExport = () => {
   const { filesystem, projectStore } = useContext(
     InfrastructureAdaptersContext
   );
   const { adapter } = useContext(RepresentationTransformContext);
+  const { view, convertFromProseMirror } = useContext(ProseMirrorContext);
   const { activeTemplate } = useContext(ExportTemplatesContext);
   const { dispatchNotification } = useContext(NotificationsContext);
   const { projectId: projectIdParam } = useParams();
@@ -163,6 +168,49 @@ export const useExport = () => {
       }
     };
 
+  // Read at render time: the palette re-renders when it opens, and the
+  // editor selection cannot change while it is open.
+  const canCopySelection = Boolean(view && !view.state.selection.empty);
+
+  const copySelectionToClipboard =
+    (representation: TextRichTextRepresentation) => async () => {
+      try {
+        if (!view) {
+          throw new Error(
+            'No editor view available when trying to copy the selection'
+          );
+        }
+
+        const selectionDoc = docFromSelection(view.state);
+
+        if (!selectionDoc) {
+          throw new Error('No selection to copy');
+        }
+
+        const text = await convertFromProseMirror({
+          pmDoc: selectionDoc,
+          to: representation,
+        });
+
+        await navigator.clipboard.writeText(text);
+        dispatchNotification(
+          createSuccessNotification({
+            title: 'Copied to Clipboard',
+            message: 'The selection was copied to the clipboard.',
+          })
+        );
+      } catch (err) {
+        console.error(err);
+        dispatchNotification(
+          createErrorNotification({
+            title: 'Copy to Clipboard Error',
+            message:
+              'An error happened when trying to copy the selection to the clipboard. Please try again.',
+          })
+        );
+      }
+    };
+
   return {
     getExportText,
     getExportBinaryData,
@@ -170,5 +218,7 @@ export const useExport = () => {
     exportToBinary,
     exportToPDF,
     copyTextToClipboard,
+    copySelectionToClipboard,
+    canCopySelection,
   };
 };

--- a/src/renderer/src/pages/project/shared/command-palette/index.tsx
+++ b/src/renderer/src/pages/project/shared/command-palette/index.tsx
@@ -47,8 +47,14 @@ export const ProjectCommandPalette = ({
   const { selection, startCreateDirectory } = useDocumentExplorerTree();
   const clearWebStorage = useClearWebStorage();
 
-  const { exportToText, exportToBinary, exportToPDF, copyTextToClipboard } =
-    useExport();
+  const {
+    exportToText,
+    exportToBinary,
+    exportToPDF,
+    copyTextToClipboard,
+    copySelectionToClipboard,
+    canCopySelection,
+  } = useExport();
 
   const openableDocuments = useMemo(
     () =>
@@ -110,6 +116,16 @@ export const ProjectCommandPalette = ({
       name: 'Copy as Markdown',
       onActionSelection: copyTextToClipboard(richTextRepresentations.MARKDOWN),
     },
+    ...(canCopySelection
+      ? [
+          {
+            name: 'Copy selection as Markdown',
+            onActionSelection: copySelectionToClipboard(
+              richTextRepresentations.MARKDOWN
+            ),
+          },
+        ]
+      : []),
     {
       name: keyBindings.ctrlShiftM.command,
       shortcut: keyBindings.ctrlShiftM.keyBinding,


### PR DESCRIPTION
Part of #178. Builds on the whole-document "Copy as Markdown" action (#409) and reuses the E2E clipboard/palette helpers from #422.

Adds a **Copy selection as Markdown** action to the command palette, shown only when the editor has a non-empty selection. The whole-document "Copy as Markdown" action from #409 is unchanged.

## How the selection becomes a valid document

An arbitrary selection is not a valid document (it can start mid-word, cut through list items, etc.), so a new `docFromSelection` helper closes it into the smallest valid standalone doc before it goes through the PROSEMIRROR → MARKDOWN transform:

1. Cut the selected range out of the deepest node that contains all of it, so context that isn't needed is dropped (a word inside a list item copies as `word`, not `- word`).
2. Wrap the cut fragment back in copies of its actual ancestors until it is valid top-level content — list items keep their list *and its type* (a bullet list never turns into an ordered one), and `createAndFill` patches up boundary nodes missing required children.
3. Validate with `doc.check()`; if the structure still can't be closed (e.g. a cut that leaves a list item without its leading paragraph), fall back to copying the selected plain text, one paragraph per block.

Resulting semantics, covered by unit tests:
- Word in a paragraph → bare text; selection spanning blocks → both blocks kept.
- Selection across list items keeps the list and its type; within a single item, drops the list.
- Partial heading/code block keeps the block (level and language attributes preserved).
- Fully-selected paragraphs inside a blockquote drop the quote (it isn't structurally required).
- Node selections (e.g. a figure) copy as-is.

The selection is read from the live `EditorView` (`ProseMirrorContext`), so it copies exactly what is on screen. Document metadata (`pandocMeta`) is deliberately not carried over, so no frontmatter leaks into a selection copy.

## E2E tests

`e2e/exports/markdown-selection.spec.ts` reuses the shared `runPaletteAction`/`readClipboardText`/`clearClipboard` helpers introduced in #422 and covers:
- Selecting the body paragraph of `hello.md` and copying it: the clipboard gets the paragraph but not the heading.
- With no selection, the palette offers "Copy as Markdown" but hides "Copy selection as Markdown".

Known edge case: a selection containing a footnote reference copies the reference without its definition when the definition lies outside the selection.
