### PR TITLE
Enable running multiple dev instances of the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-*
 dist-ssr
+.dev-peers
 *.local
 
 # Electron build output

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,8 @@ export default [
   {
     ignores: [
       '**/dist/**',
+      'dist-*/**',
+      '.dev-peers/**',
       '**/.eslintrc.cjs',
       'e2e-results/**',
       'storybook-static/**',

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "build": "electron-vite build --outDir=dist",
     "compile": "tsc",
     "dev": "electron-vite dev -w --outDir=dist",
+    "dev:alice": "node scripts/dev-peer.mjs alice",
+    "dev:bob": "node scripts/dev-peer.mjs bob",
     "debug": "electron-vite dev -w --outDir=dist -- --inspect=9229",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 100",
     "lint:fix": "eslint . --fix --report-unused-disable-directives --max-warnings 100",

--- a/scripts/dev-peer.mjs
+++ b/scripts/dev-peer.mjs
@@ -1,0 +1,41 @@
+// Launches a self-sufficient, isolated dev instance ("peer"): a full
+// `electron-vite dev` with its own output dir (so parallel instances never
+// clobber each other's bundles), its own Vite port (auto-picked), and its own
+// persistent user-data dir under .dev-peers/ — own single-instance lock, own
+// localStorage/config, remembered across runs.
+import { spawn } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+const name = process.argv[2];
+if (!name) {
+  console.error('Usage: node scripts/dev-peer.mjs <name>');
+  process.exit(1);
+}
+
+const outDir = `dist-${name}`;
+const userDataDir = resolve('.dev-peers', name);
+mkdirSync(userDataDir, { recursive: true });
+
+console.log(`[${name}] user data: ${userDataDir}`);
+console.log(`[${name}] out dir: ${outDir}`);
+
+const child = spawn(
+  'pnpm',
+  [
+    'exec',
+    'electron-vite',
+    'dev',
+    '-w',
+    `--outDir=${outDir}`,
+    '--',
+    `--user-data-dir=${userDataDir}`,
+  ],
+  {
+    shell: process.platform === 'win32',
+    stdio: 'inherit',
+  }
+);
+
+child.on('exit', (code) => process.exit(code ?? 0));


### PR DESCRIPTION
## Description

Enable running multiple dev instances of the app. There are two new package.json scripts (`dev:alice` and `dev:bob`) which runs dev instances for these two test users who get (gitignored) user-data folders in the repo root.

## Related Issue

Closes #420 

