### PR TITLE
test: add E2E test for the copy as Markdown palette action

### DIFF
--- a/e2e/exports/markdown.spec.ts
+++ b/e2e/exports/markdown.spec.ts
@@ -1,0 +1,62 @@
+import { ElectronApplication, Page } from '@playwright/test';
+
+import { expect, test } from '../shared/fixtures';
+import {
+  openCommandPalette,
+  openHelloMd,
+  openProjectFolder,
+} from '../shared/helpers';
+
+const readClipboardText = async ({
+  electronApp,
+}: {
+  electronApp: ElectronApplication;
+}): Promise<string> =>
+  electronApp.evaluate(({ clipboard }) => clipboard.readText());
+
+const clearClipboard = async ({
+  electronApp,
+}: {
+  electronApp: ElectronApplication;
+}): Promise<void> => electronApp.evaluate(({ clipboard }) => clipboard.clear());
+
+const runPaletteAction = async ({
+  window,
+  actionName,
+}: {
+  window: Page;
+  actionName: string;
+}): Promise<void> => {
+  await openCommandPalette({ window });
+
+  const option = window.getByRole('option', { name: actionName, exact: true });
+  await option.waitFor({ state: 'visible', timeout: 5_000 });
+  await option.click();
+};
+
+test.describe('copy as markdown', () => {
+  test('copies the whole document as Markdown to the clipboard', async ({
+    electronApp,
+    window,
+    testProjectDir,
+  }) => {
+    await openProjectFolder({
+      electronApp,
+      window,
+      folderPath: testProjectDir,
+    });
+    await openHelloMd({ window });
+    await clearClipboard({ electronApp });
+
+    await runPaletteAction({ window, actionName: 'Copy as Markdown' });
+
+    // The success notification confirms the clipboard write completed
+    await expect(window.getByText('Copied to Clipboard')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const clipboardText = await readClipboardText({ electronApp });
+    expect(clipboardText).toContain('# Hello');
+    expect(clipboardText).toContain('This is a test document.');
+  });
+});

--- a/e2e/exports/markdown.spec.ts
+++ b/e2e/exports/markdown.spec.ts
@@ -1,38 +1,11 @@
-import { ElectronApplication, Page } from '@playwright/test';
-
 import { expect, test } from '../shared/fixtures';
 import {
-  openCommandPalette,
+  clearClipboard,
   openHelloMd,
   openProjectFolder,
+  readClipboardText,
+  runPaletteAction,
 } from '../shared/helpers';
-
-const readClipboardText = async ({
-  electronApp,
-}: {
-  electronApp: ElectronApplication;
-}): Promise<string> =>
-  electronApp.evaluate(({ clipboard }) => clipboard.readText());
-
-const clearClipboard = async ({
-  electronApp,
-}: {
-  electronApp: ElectronApplication;
-}): Promise<void> => electronApp.evaluate(({ clipboard }) => clipboard.clear());
-
-const runPaletteAction = async ({
-  window,
-  actionName,
-}: {
-  window: Page;
-  actionName: string;
-}): Promise<void> => {
-  await openCommandPalette({ window });
-
-  const option = window.getByRole('option', { name: actionName, exact: true });
-  await option.waitFor({ state: 'visible', timeout: 5_000 });
-  await option.click();
-};
 
 test.describe('copy as markdown', () => {
   test('copies the whole document as Markdown to the clipboard', async ({

--- a/e2e/shared/helpers.ts
+++ b/e2e/shared/helpers.ts
@@ -198,6 +198,44 @@ export const openCommandPalette = async ({
   await window.waitForTimeout(300);
 };
 
+/**
+ * Opens the command palette and clicks the action with the given name.
+ */
+export const runPaletteAction = async ({
+  window,
+  actionName,
+}: {
+  window: Page;
+  actionName: string;
+}): Promise<void> => {
+  await openCommandPalette({ window });
+
+  const option = window.getByRole('option', { name: actionName, exact: true });
+  await option.waitFor({ state: 'visible', timeout: 5_000 });
+  await option.click();
+};
+
+/**
+ * Reads the system clipboard through Electron's clipboard module in the
+ * main process.
+ */
+export const readClipboardText = async ({
+  electronApp,
+}: {
+  electronApp: ElectronApplication;
+}): Promise<string> =>
+  electronApp.evaluate(({ clipboard }) => clipboard.readText());
+
+/**
+ * Clears the system clipboard, so a test cannot pass on a value left over
+ * from a previous copy.
+ */
+export const clearClipboard = async ({
+  electronApp,
+}: {
+  electronApp: ElectronApplication;
+}): Promise<void> => electronApp.evaluate(({ clipboard }) => clipboard.clear());
+
 export const openHelloMd = async ({
   window,
 }: {


### PR DESCRIPTION
Addresses the [review comment on #409](https://github.com/oktana-coop/v2/pull/409#pullrequestreview-4891723899) asking for E2E coverage of the copy-as-Markdown action.

Adds `e2e/exports/markdown.spec.ts` with a test that opens a document, runs **Copy as Markdown** from the command palette, and asserts the document's Markdown ends up in the system clipboard (read via Electron's `clipboard` module in the main process). The success notification is asserted first, which also guarantees the clipboard write has completed.

E2E coverage for **Copy selection as Markdown** lives in #410 together with the feature.