### PR TITLE
fix: stop the command palette from unfiltering while it fades out

### DIFF
--- a/src/renderer/src/components/dialogs/command-palette/CommandPalette.tsx
+++ b/src/renderer/src/components/dialogs/command-palette/CommandPalette.tsx
@@ -8,7 +8,7 @@ import {
   DialogBackdrop,
   DialogPanel,
 } from '@headlessui/react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { type KeyBinding, useKeyBindings } from '../../../keyboard';
@@ -70,18 +70,15 @@ export type CommandPaletteProps = {
 export const CommandPaletteInput = ({
   placeholder,
   onChange,
-  onBlur,
 }: {
   placeholder: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  onBlur: React.FocusEventHandler<HTMLInputElement> | undefined;
 }) => (
   <ComboboxInput
     autoFocus
     className="col-start-1 row-start-1 h-12 w-full bg-transparent p-4 text-base text-gray-900 outline-none placeholder:text-gray-500 sm:text-sm dark:text-gray-100 dark:placeholder:text-gray-300"
     placeholder={placeholder}
     onChange={onChange}
-    onBlur={onBlur}
   />
 );
 
@@ -177,6 +174,16 @@ export const CommandPalette = ({
   contextualSection,
 }: CommandPaletteProps) => {
   const [query, setQuery] = useState('');
+
+  // Reset the query when the palette opens, not when it closes: the dialog
+  // stays mounted during its leave transition, and clearing the query then
+  // makes the full unfiltered list flash while it fades out.
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+    }
+  }, [open]);
+
   const allActions = [...actions, ...(contextualSection?.actions || [])];
   const actionsKeyBindings = allActions
     .filter((action) => action.shortcut)
@@ -210,14 +217,7 @@ export const CommandPalette = ({
         });
 
   return (
-    <Dialog
-      className="relative z-10"
-      open={open}
-      onClose={() => {
-        onClose();
-        setQuery('');
-      }}
-    >
+    <Dialog className="relative z-10" open={open} onClose={onClose}>
       <DialogBackdrop
         transition
         className="fixed inset-0 bg-gray-500/25 transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in"
@@ -232,7 +232,6 @@ export const CommandPalette = ({
             onChange={(option: DocumentOption | ActionOption | null) => {
               if (option === null) return;
               onClose();
-              setQuery('');
               if (isDocumentOption(option)) {
                 option.onDocumentSelection();
               } else {
@@ -249,9 +248,6 @@ export const CommandPalette = ({
                 placeholder="Search..."
                 onChange={(event) => {
                   setQuery(event.target.value);
-                }}
-                onBlur={() => {
-                  setQuery('');
                 }}
               />
             </div>

--- a/src/renderer/src/pages/project/current-project/branching/branching-command-palette/index.tsx
+++ b/src/renderer/src/pages/project/current-project/branching/branching-command-palette/index.tsx
@@ -37,6 +37,13 @@ export const BranchingCommandPalette = ({
   currentBranch,
 }: BranchingCommandPaletteProps) => {
   const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+    }
+  }, [open]);
+
   const [branches, setBranches] = useState<Branch[] | null>(null);
   const [branchActionOptions, setBranchActionOptions] = useState<
     ActionOption[]
@@ -153,14 +160,7 @@ export const BranchingCommandPalette = ({
   ]);
 
   return (
-    <Dialog
-      className="relative z-10"
-      open={open}
-      onClose={() => {
-        onClose();
-        setQuery('');
-      }}
-    >
+    <Dialog className="relative z-10" open={open} onClose={onClose}>
       <div className="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:p-20">
         <DialogPanel
           transition
@@ -170,7 +170,6 @@ export const BranchingCommandPalette = ({
             onChange={(option: ActionOption | null) => {
               if (option === null) return;
               onClose();
-              setQuery('');
 
               // as the Command Palette dialog has a smooth transition out effect (see data-[leave]:duration-200 above)
               // we trigger the action selection after a short delay
@@ -184,9 +183,6 @@ export const BranchingCommandPalette = ({
                 placeholder="Search for branches and actions"
                 onChange={(event) => {
                   setQuery(event.target.value);
-                }}
-                onBlur={() => {
-                  setQuery('');
                 }}
               />
             </div>


### PR DESCRIPTION
Closes #423.

The Headless UI dialog stays mounted during its 200ms leave transition, but the query was cleared as soon as an option was picked (and on input blur), so the palette re-rendered unfiltered and the full list flashed while fading out.

The query is now reset when the palette opens instead of when it closes, so the filtered view stays frozen during the close transition. The `onBlur` reset on `CommandPaletteInput` is removed entirely (clicking an option blurs the input, which triggered the same flash); the branching palette had the identical pattern and gets the same fix.

No behavior change on open: the input is uncontrolled and remounts empty each time the dialog opens, so resetting the query there just keeps the filter state in line with it.
